### PR TITLE
Fixes #17 wrong url path for vision_wasm

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "dependencies": {
     "@mediapipe/holistic": "0.5.1675471629",
-    "@mediapipe/tasks-vision": "0.10.5"
+    "@mediapipe/tasks-vision": "0.10.6"
   },
   "peerDependencies": {
     "livekit-client": "^1.12.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -690,10 +690,10 @@
   resolved "https://registry.yarnpkg.com/@mediapipe/holistic/-/holistic-0.5.1675471629.tgz#f1127d43161ff27e8889d5d39aaea164f9730980"
   integrity sha512-qY+cxtDeSOvVtevrLgnodiwXYaAtPi7dHZtNv/bUCGEjFicAOYtMmrZSqMmbPkTB2+4jLnPF1vgshkAqQRSYAw==
 
-"@mediapipe/tasks-vision@0.10.5":
-  version "0.10.5"
-  resolved "https://registry.yarnpkg.com/@mediapipe/tasks-vision/-/tasks-vision-0.10.5.tgz#09cfcf873a1056e1e80b9c6fe3b9f2c1836cb1ea"
-  integrity sha512-pCLvVEx917KHMYlIP/TqJH0XnO3ryObl5ox2l8cKSFGIWvmT9bKCq+lsD4N89UaslxEkB6ofPLRD2mOm01n1qA==
+"@mediapipe/tasks-vision@0.10.6":
+  version "0.10.6"
+  resolved "https://registry.yarnpkg.com/@mediapipe/tasks-vision/-/tasks-vision-0.10.6.tgz#f2000eddb8bec0367fbc5f044ff2ecb87e5f38d9"
+  integrity sha512-DzWMTI0FIeIPsVqnFKRKFQ3yng9qrtT3YuYkGNVeoob12br4+MVoLFlfkKP36mIAYM9/Vj2SarXCvTA14rdQsQ==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"


### PR DESCRIPTION
update @mediapipe/tasks-vision to v0.10.6

Duplicated #18 but now CLA is signed.