### PR TITLE
Added mediapipe dependencies as peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "@mediapipe/tasks-vision": "0.10.6"
   },
   "peerDependencies": {
-    "livekit-client": "^1.12.0"
+    "livekit-client": "^1.12.0",
+    "@mediapipe/holistic": "0.5.1675471629",
+    "@mediapipe/tasks-vision": "0.10.6"
   },
   "devDependencies": {
     "@changesets/cli": "^2.26.2",


### PR DESCRIPTION
The track-processors-js should include its dependencies as peer dependencies with the aim of working ot of the box when install it in a project. 

Without this peer dependencies, you need to install them manually. 