### PR TITLE
Reload the background image when needed during processor initialization

### DIFF
--- a/.changeset/mighty-pandas-change.md
+++ b/.changeset/mighty-pandas-change.md
@@ -1,0 +1,5 @@
+---
+"@livekit/track-processors": patch
+---
+
+Reload the background image when needed during processor initialization

--- a/src/transformers/BackgroundTransformer.ts
+++ b/src/transformers/BackgroundTransformer.ts
@@ -56,7 +56,10 @@ export default class BackgroundProcessor extends VideoTransformer<BackgroundOpti
       outputConfidenceMasks: false,
     });
 
-    // this.loadBackground(opts.backgroundUrl).catch((e) => console.error(e));
+    // Skip loading the image here if update already loaded the image below
+    if (this.options?.imagePath && !this.backgroundImage) {
+      await this.loadBackground(this.options.imagePath).catch((err) => console.error("Error while loading processor background image: ", err));
+    }
   }
 
   async destroy() {


### PR DESCRIPTION
This resolves #41 by reloading the background image during initialization only when needed. This should prevent showing the green backgrounds when disabling and re-enabling video tracks with active virtual backgrounds.