### PR TITLE
Use putImageData instead of creating new bitmap

### DIFF
--- a/.changeset/tall-peas-reflect.md
+++ b/.changeset/tall-peas-reflect.md
@@ -1,0 +1,5 @@
+---
+"@livekit/track-processors": patch
+---
+
+Use putImageData instead of creating new bitmap


### PR DESCRIPTION
increases performance by ~15% by avoiding the call to `createImageBitmap`