### PR TITLE
fix: configurable asset paths for BackgroundProcessor

### DIFF
--- a/.changeset/shy-toes-talk.md
+++ b/.changeset/shy-toes-talk.md
@@ -1,0 +1,5 @@
+---
+'@livekit/track-processors': patch
+---
+
+Adds missing object variable "assetPaths" for configurable asset paths in BackgroundProcessor.

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ export interface BackgroundProcessorOptions extends ProcessorWrapperOptions {
   blurRadius?: number;
   imagePath?: string;
   segmenterOptions?: SegmenterOptions;
+  assetPaths?: { tasksVisionFileSet?: string; modelAssetPath?: string };
   onFrameProcessed?: (stats: FrameProcessingStats) => void;
 }
 
@@ -86,10 +87,23 @@ export const BackgroundProcessor = (
   }
 
   // Extract transformer-specific options and processor options
-  const { blurRadius, imagePath, segmenterOptions, onFrameProcessed, ...processorOpts } = options;
+  const {
+    blurRadius,
+    imagePath,
+    segmenterOptions,
+    assetPaths,
+    onFrameProcessed,
+    ...processorOpts
+  } = options;
 
   const processor = new ProcessorWrapper(
-    new BackgroundTransformer({ blurRadius, imagePath, segmenterOptions, onFrameProcessed }),
+    new BackgroundTransformer({
+      blurRadius,
+      imagePath,
+      segmenterOptions,
+      assetPaths,
+      onFrameProcessed,
+    }),
     name,
     processorOpts,
   );


### PR DESCRIPTION
Adds missing object variable "assetPaths" for configurable asset paths in BackgroundProcessor.