### PR TITLE
Update mask when ready

### DIFF
--- a/.changeset/twenty-swans-serve.md
+++ b/.changeset/twenty-swans-serve.md
@@ -1,0 +1,5 @@
+---
+"@livekit/track-processors": patch
+---
+
+Update mask when ready


### PR DESCRIPTION
Previously the render pipeline was executed concurrently waiting for the segmentation step to finish before rendering the frame

```
VideoFrame -> Segmentation -> render with newest segmentation mask and video frame
```

this PR changes this to be executed concurrently so that the rendering pipeline is not blocked by the segmentation step. 

```
VideoFrame  -> Segmentation -> update segmentation mask
            -> render frame with latest available segmentation mask
```

This leads to the most recent camera frame being drawn immediately with a (potentially) outdated segmentation mask. Expectation is for the segmentation to be consistently 1 frame behind the actual frame, which is not noticeable in my testing.

In order to avoid reading and writing to the same texture at the same time, this PR also adds double buffering for the final mask texture

