### PR TITLE
fix(package.json): correct repository field URL format and target the…

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "module": "dist/index.mjs",
   "source": "src/index.ts",
   "types": "dist/src/index.d.ts",
-  "repository": "git@github.com:livekit/livekit-track-processors.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/livekit/track-processors-js.git"
+  },
   "author": "Lukas Seiler",
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
### Update `repository` field in `package.json`

This PR updates the `repository` field in `package.json` to follow the correct structure and point to the right GitHub repository:

#### 🔧 Change made:
```diff
- "repository": "git@github.com:livekit/livekit-track-processors.git",
+ "repository": {
+   "type": "git",
+   "url": "https://github.com/livekit/track-processors-js.git"
+ }
```

#### Why this change:
- Ensures the repository field is in the correct [[npm-compatible format](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#repository)](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#repository).
- Corrects the repository URL to reflect the actual location of the project (`track-processors-js`).
- Helps tools like npm and GitHub correctly link to the source code and improve metadata in package listings.
