### PR TITLE
Use pnpm in readme, since that is the lockfile type that is committed

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ export const VirtualBackground = (imagePath: string) => {
 This repository includes a small example app built on [Vite](https://vitejs.dev/). Run it with:
 
 ```
-npm install
-npm run sample
+# install pnpm: https://pnpm.io/installation
+pnpm install
+pnpm sample
 ```


### PR DESCRIPTION
The README referenced `npm install`, but a `pnpm-lock.yaml` file was in the root, and no `package-lock.json` seems to be there. Given this, update the README to use `pnpm` and not `npm`.