### PR TITLE
Update example to hot-switch between blur and virtual bg rather than tear down / recreate the media pipeline

### DIFF
--- a/src/transformers/BackgroundTransformer.ts
+++ b/src/transformers/BackgroundTransformer.ts
@@ -161,10 +161,12 @@ export default class BackgroundProcessor extends VideoTransformer<BackgroundOpti
 
   async update(opts: BackgroundOptions) {
     this.options = { ...this.options, ...opts };
-    if (opts.blurRadius) {
-      this.gl?.setBlurRadius(opts.blurRadius);
-    } else if (opts.imagePath) {
+
+    this.gl?.setBlurRadius(opts.blurRadius ?? null);
+    if (opts.imagePath) {
       await this.loadBackground(opts.imagePath);
+    } else {
+      this.gl?.setBackgroundImage(null);
     }
   }
 


### PR DESCRIPTION
Update the in-built example to use `updateTransformerOptions` to switch the active transformer from blur background to virtual background (as it supports both modes) rather than fully tearing down and fully setting up the whole transformer in a new configuration with `stopProcessor` / `setProcessor`. By doing this, quite a bit of the flickering is eliminated on chrome, firefox, and safari (see videos below for some demos).

Note that this doesn't do anything about the initial `setProcessor` call, and a fair bit of visual artifacts still exist there. I think removing these is going to require digging deeper into the media processing pipeline, my suspicion is that the "stages" of that artifact line up with some async operations that the media pipeline is performing as part of its setup logic.

Associated with https://github.com/livekit/track-processors-js/issues/85

# Demo videos

Chrome:

https://github.com/user-attachments/assets/2230a172-fcbe-4d32-b6ff-e650413e6a17


Firefox:


https://github.com/user-attachments/assets/30b380db-471c-4a2e-8820-c405402be3cb



Safari:


https://github.com/user-attachments/assets/c7c91561-91b7-4a2e-a91e-c103ba314192

