### PR TITLE
Add new `BackgroundProcessorManager` to provide a better interface for changing between background blur / virtual background

### DIFF
--- a/.changeset/busy-days-sell.md
+++ b/.changeset/busy-days-sell.md
@@ -1,0 +1,5 @@
+---
+'@livekit/track-processors': minor
+---
+
+Add new BackgroundProcessorManager to provide a better interface for changing between background blur / virtual background

--- a/README.md
+++ b/README.md
@@ -3,22 +3,29 @@
 ## Install
 
 ```
-npm add @livekit/track-processors
+npm install @livekit/track-processors
 ```
 
-## Usage of prebuilt processors
+## Usage of prebuilt processor
 
 ### Available processors
 
-This package exposes the `BackgroundBlur` and `VirtualBackground` pre-prepared processor pipelines.
+This package exposes the `BackgroundProcessorManager` pre-prepared processor pipeline. This single
+processor pipeline supports both background blur and substituting a user's background for a virtual
+image:
 
-- `BackgroundBlur(blurRadius)`
-- `VirtualBackground(imagePath)`
+```typescript
+// Background Blur
+BackgroundProcessorManager.withBackgroundBlur(/* optional blurRadius */)
+
+// Virtual Background
+BackgroundProcessorManager.withVirtualBackground(imagePath)
+```
 
 ### Usage example
 
 ```ts
-import { BackgroundBlur, supportsBackgroundProcessors, supportsModernBackgroundProcessors } from '@livekit/track-processors';
+import { BackgroundProcessorManager, supportsBackgroundProcessors, supportsModernBackgroundProcessors } from '@livekit/track-processors';
 
 if(!supportsBackgroundProcessors()) {
   throw new Error("this browser does not support background processors")
@@ -29,8 +36,8 @@ if(supportsModernBackgroundProcessors()) {
 }
 
 const videoTrack = await createLocalVideoTrack();
-const blur = BackgroundBlur(10);
-await videoTrack.setProcessor(blur);
+const processor = BackgroundProcessorManager.withBackgroundBlur(10);
+await videoTrack.setProcessor(processor);
 room.localParticipant.publishTrack(videoTrack);
 
 async function disableBackgroundBlur() {
@@ -38,10 +45,12 @@ async function disableBackgroundBlur() {
 }
 
 async updateBlurRadius(radius) {
-  return blur.updateTransformerOptions({blurRadius: radius})
+  return processor.switchToBackgroundBlur(radius);
 }
 
-
+async liveUpdateToBackgroundImage(image) {
+  return processor.switchToVirtualBackground(image);
+}
 ```
 
 ## Developing your own processors

--- a/example/sample.ts
+++ b/example/sample.ts
@@ -24,18 +24,17 @@ import {
   facingModeFromLocalTrack,
   setLogLevel,
 } from 'livekit-client';
-import { BackgroundProcessor } from '../src';
+import { BackgroundProcessorManager } from '../src';
 
 const $ = <T extends HTMLElement>(id: string) => document.getElementById(id) as T;
 
-const BLUR_RADIUS = 10;
 const IMAGE_PATH = '/samantha-gades-BlIhVfXbi9s-unsplash.jpg';
 
 const state = {
   defaultDevices: new Map<MediaDeviceKind, string>(),
   bitrateInterval: undefined as any,
   backgroundProcessorMode: null as ('virtual-background' | 'background-blur' | null),
-  backgroundProcessor: BackgroundProcessor({
+  backgroundProcessor: BackgroundProcessorManager.withOptions({
     // onFrameProcessed: (stats) => console.log('frame processing stats', stats),
   }),
 };

--- a/example/sample.ts
+++ b/example/sample.ts
@@ -24,7 +24,7 @@ import {
   facingModeFromLocalTrack,
   setLogLevel,
 } from 'livekit-client';
-import { BackgroundBlur, VirtualBackground } from '../src';
+import { VirtualBackground } from '../src';
 
 const $ = <T extends HTMLElement>(id: string) => document.getElementById(id) as T;
 
@@ -34,9 +34,6 @@ const IMAGE_PATH = '/samantha-gades-BlIhVfXbi9s-unsplash.jpg';
 const state = {
   defaultDevices: new Map<MediaDeviceKind, string>(),
   bitrateInterval: undefined as any,
-  blur: BackgroundBlur(BLUR_RADIUS, undefined, (stats) => {
-    // console.log('frame processing stats', stats);
-  }),
   virtualBackground: VirtualBackground(IMAGE_PATH, undefined, (stats) => {
     // console.log('frame processing stats', stats);
   }),
@@ -260,10 +257,6 @@ const appActions = {
           break;
 
         case 'virtual-background':
-          // This could also work, but it results in a visual artifact when switching:
-          // await camTrack.setProcessor(state.blur);
-          // await camTrack.stopProcessor();
-
           const virtualBackgroundProcessor = processor as typeof state.virtualBackground;
           await virtualBackgroundProcessor.updateTransformerOptions({
             imagePath: undefined,
@@ -276,13 +269,13 @@ const appActions = {
         default:
           // NOTE: Since state.blur may have been updated ad-hoc in `toggleVirtualBackground`,
           // when switching, inject the right params in just to be 100% sure they are correct
-          await state.blur.updateTransformerOptions({
+          await state.virtualBackground.updateTransformerOptions({
             imagePath: undefined,
             blurRadius: BLUR_RADIUS,
           });
-          state.blur.name = 'background-blur';
+          state.virtualBackground.name = 'background-blur';
 
-          await camTrack.setProcessor(state.blur);
+          await camTrack.setProcessor(state.virtualBackground);
           break;
       }
     } catch (e: any) {
@@ -307,11 +300,7 @@ const appActions = {
           break;
 
         case 'background-blur':
-          // This could also work, but it results in a visual artifact when switching:
-          // await camTrack.setProcessor(state.virtualBackground);
-          // await camTrack.stopProcessor();
-
-          const blurProcessor = processor as typeof state.blur;
+          const blurProcessor = processor as typeof state.virtualBackground;
           await blurProcessor.updateTransformerOptions({
             imagePath: IMAGE_PATH,
             blurRadius: undefined,

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ export const BackgroundBlur = (
     blurRadius,
     segmenterOptions,
     onFrameProcessed,
-    processorOptions
+    processorOptions,
   );
   processor.name = 'background-blur';
   return processor;
@@ -69,7 +69,7 @@ export const VirtualBackground = (
     imagePath,
     segmenterOptions,
     onFrameProcessed,
-    processorOptions
+    processorOptions,
   );
   processor.name = 'virtual-background';
   return processor;
@@ -86,8 +86,16 @@ export const BackgroundProcessor = (
   return BackgroundProcessorManager.withOptions(options, name);
 };
 
-
-export default class BackgroundProcessorManager extends ProcessorWrapper<BackgroundOptions> {
+/**
+ * A preconfigured background processor that supports blurring the background of a user's local
+ * video, or replacing the user's background with a virtual background image, and switching the
+ * active mode later on the fly to avoid visual artifacts.
+ *
+ * @example
+ * const camTrack = currentRoom.localParticipant.getTrackPublication(Track.Source.Camera)!.track as LocalVideoTrack;
+ * camTrack.setProcessor(BackgroundProcessorManager.withBackgroundBlur());
+ */
+export class BackgroundProcessorManager extends ProcessorWrapper<BackgroundOptions> {
   static withOptions(options: BackgroundProcessorOptions, name = 'background-processor') {
     const isTransformerSupported = BackgroundTransformer.isSupported;
     const isProcessorSupported = ProcessorWrapper.isSupported;
@@ -124,38 +132,40 @@ export default class BackgroundProcessorManager extends ProcessorWrapper<Backgro
     return instance;
   }
 
+  /**
+   * Creates a preconfigured background processor which blurs a user's background. To switch
+   * modes, see `switchToVirtualBackground`.
+   */
   static withBackgroundBlur(
     blurRadius: number = 10,
     segmenterOptions?: SegmenterOptions,
     onFrameProcessed?: (stats: FrameProcessingStats) => void,
     processorOptions?: ProcessorWrapperOptions,
   ) {
-    return this.withOptions(
-      {
-        blurRadius,
-        segmenterOptions,
-        onFrameProcessed,
-        ...processorOptions,
-      },
-      // 'background-blur'
-    );
+    return this.withOptions({
+      blurRadius,
+      segmenterOptions,
+      onFrameProcessed,
+      ...processorOptions,
+    });
   }
 
+  /**
+   * Creates a preconfigured background processor which replaces a user's background with a virtual
+   * image. To switch modes, see `switchToVirtualBackground`.
+   */
   static withVirtualBackground(
     imagePath: string,
     segmenterOptions?: SegmenterOptions,
     onFrameProcessed?: (stats: FrameProcessingStats) => void,
     processorOptions?: ProcessorWrapperOptions,
   ) {
-    return this.withOptions(
-      {
-        imagePath,
-        segmenterOptions,
-        onFrameProcessed,
-        ...processorOptions,
-      },
-      // 'virtual-background',
-    );
+    return this.withOptions({
+      imagePath,
+      segmenterOptions,
+      onFrameProcessed,
+      ...processorOptions,
+    });
   }
 
   async switchToBackgroundBlur(blurRadius: number = 10) {


### PR DESCRIPTION
Previously, switching between these two modes was relatively unintuitive, and not well documented. https://github.com/livekit/track-processors-js/pull/94 was a good first pass at this, but I thought there was a potential for some sort of better interface so I gave that a shot here. See the `README` for a usage example!

Also, while I was in here, I added a fair number of documentation comments to try to point folks towards the new interfaces.