### PR TITLE
Reduce the intensity of the gray "flash" when enabling the `BackgroundProcessor`

### DIFF
--- a/src/transformers/BackgroundTransformer.ts
+++ b/src/transformers/BackgroundTransformer.ts
@@ -155,7 +155,7 @@ export default class BackgroundProcessor extends VideoTransformer<BackgroundOpti
         try {
           let segmentationStartTimeMs = performance.now();
           // NOTE: this.imageSegmenter?.segmentForVideo is synchronous, and blocks the event loop
-          // for 10s of ms! The promise wrapper is just used to flatten out the call hierarchy.
+          // for tens to ~100 ms! The promise wrapper is just used to flatten out the call hierarchy.
           this.imageSegmenter?.segmentForVideo(frame, segmentationStartTimeMs, (result) => {
             this.segmentationTimeMs = performance.now() - segmentationStartTimeMs;
             this.segmentationResults = result;
@@ -168,7 +168,7 @@ export default class BackgroundProcessor extends VideoTransformer<BackgroundOpti
         }
       });
 
-      // NOTE: `this.drawFrame` is syncronous, and could take tens to hundreds of ms to run!
+      // NOTE: `this.drawFrame` is synchronous, and could take tens of ms to run!
       this.drawFrame(frame);
       if (this.canvas && this.canvas.width > 0 && this.canvas.height > 0) {
         const newFrame = new VideoFrame(this.canvas, {

--- a/src/transformers/BackgroundTransformer.ts
+++ b/src/transformers/BackgroundTransformer.ts
@@ -42,6 +42,8 @@ export default class BackgroundProcessor extends VideoTransformer<BackgroundOpti
 
   segmentationTimeMs: number = 0;
 
+  isFirstFrame = true;
+
   constructor(opts: BackgroundOptions) {
     super();
     this.options = opts;
@@ -103,7 +105,6 @@ export default class BackgroundProcessor extends VideoTransformer<BackgroundOpti
     this.gl?.setBackgroundImage(imageData);
   }
 
-  isFirstFrame = true;
   async transform(frame: VideoFrame, controller: TransformStreamDefaultController<VideoFrame>) {
     let enqueuedFrame = false;
     try {
@@ -125,18 +126,50 @@ export default class BackgroundProcessor extends VideoTransformer<BackgroundOpti
       this.canvas.width = frame.displayWidth;
       this.canvas.height = frame.displayHeight;
 
-      // 
+      // Render a copy of the first frame is rendered to the screen as soon as possible to act
+      // as a less jarring initial state than a solid color while the synchronous work below
+      // (segmentation + frame rendering) occurs.
+      //
+      // Ideally, these sync tasks could be offloaded to a webworker, but this is challenging
+      // given WebGLTextures cannot be easily passed in a `postMessage`.
       if (this.isFirstFrame) {
-        controller.enqueue(frame);
-        enqueuedFrame = true;
-        await new Promise(r => setTimeout(r, 10));
-        // await new Promise(r => this.inputVideo);
+        controller.enqueue(frame.clone());
+
+        // Wait for the frame that was enqueued above to render before doing the sync work
+        // below - otherwise, the sync work will take over the event loop and prevent the render
+        // from occurring
+        if (this.inputVideo) {
+          await new Promise((resolve) => {
+            this.inputVideo!.requestVideoFrameCallback((_now, e) => {
+              const durationUntilFrameRenderedInMs = e.expectedDisplayTime - e.presentationTime;
+              setTimeout(resolve, durationUntilFrameRenderedInMs);
+            });
+          });
+        }
       }
+      this.isFirstFrame = false;
 
       const filterStartTimeMs = performance.now();
+
+      const segmentationPromise = new Promise<void>((resolve, reject) => {
+        try {
+          let segmentationStartTimeMs = performance.now();
+          // NOTE: this.imageSegmenter?.segmentForVideo is synchronous, and blocks the event loop
+          // for 10s of ms! The promise wrapper is just used to flatten out the call hierarchy.
+          this.imageSegmenter?.segmentForVideo(frame, segmentationStartTimeMs, (result) => {
+            this.segmentationTimeMs = performance.now() - segmentationStartTimeMs;
+            this.segmentationResults = result;
+            this.updateMask(result.categoryMask);
+            result.close();
+            resolve();
+          });
+        } catch (e) {
+          reject(e);
+        }
+      });
+
       // NOTE: `this.drawFrame` is syncronous, and could take tens to hundreds of ms to run!
       this.drawFrame(frame);
-      this.isFirstFrame = false;
       if (this.canvas && this.canvas.width > 0 && this.canvas.height > 0) {
         const newFrame = new VideoFrame(this.canvas, {
           timestamp: frame.timestamp || frameTimeMs,
@@ -152,21 +185,6 @@ export default class BackgroundProcessor extends VideoTransformer<BackgroundOpti
       } else {
         controller.enqueue(frame);
       }
-
-      const segmentationPromise = new Promise<void>((resolve, reject) => {
-        try {
-          let segmentationStartTimeMs = performance.now();
-          this.imageSegmenter?.segmentForVideo(frame, segmentationStartTimeMs, (result) => {
-            this.segmentationTimeMs = performance.now() - segmentationStartTimeMs;
-            this.segmentationResults = result;
-            this.updateMask(result.categoryMask);
-            result.close();
-            resolve();
-          });
-        } catch (e) {
-          reject(e);
-        }
-      });
       await segmentationPromise;
     } catch (e) {
       console.error('Error while processing frame: ', e);


### PR DESCRIPTION
## Background
Previously, the `BackgroundProcessor` track processor would show a brief gray flash right after being enabled on chrome, firefox, and safari - see the below video (recorded in chrome) for an example:

https://github.com/user-attachments/assets/5fc734cc-71e1-4784-8ff7-6e99da560d17

As this behavior is not ideal, I wanted to understand _why_ it happened and if there was anything I could do to fix it, or at least make it less noticeable to an end user.

## Behavior
As far as I can tell, what the "gray" state actually represents is that the media pipeline hasn't yet had a frame make its way end to end so it can be shown to a user. The gray state starts right after the `pipedStream.pipeTo(...)` [here](https://github.com/livekit/track-processors-js/blob/3920c38b280accbd26152324bfd9298cc27949a9/src/ProcessorWrapper.ts#L174-L175) under the stream processor path, and after the render loop starts [here](https://github.com/livekit/track-processors-js/blob/3920c38b280accbd26152324bfd9298cc27949a9/src/ProcessorWrapper.ts#L233) under the fallback path, and in both cases it ends once the `transform` handler [here](https://github.com/livekit/track-processors-js/blob/3920c38b280accbd26152324bfd9298cc27949a9/src/transformers/BackgroundTransformer.ts#L105-L160) finishes.

That brings up an important question though - why does it take so long (sometimes upwards of 100ms) for the first frame to be processed? The reason is because of the mediapipe vision [`segmentForVideo` call here](https://github.com/livekit/track-processors-js/blob/3920c38b280accbd26152324bfd9298cc27949a9/src/transformers/BackgroundTransformer.ts#L122-L135), and to a lesser degree, the [`drawFrame` call here](https://github.com/livekit/track-processors-js/blob/3920c38b280accbd26152324bfd9298cc27949a9/src/transformers/BackgroundTransformer.ts#L138). Both calls are synchronous and block the event loop - in addition, `segmentForVideo` for some reason takes especially long to run for the first frame (most frames it takes a couple ms at max, but the first frame could be nearly 100ms (!), accounting for most of the gray state time).

What happens on the first frame looks something like this:
1. The `ProcessorWrapper` media pipeline stack gets constructed (either implementation), and the output video turns gray because no frames have been processed yet.
2. `transform` [here](https://github.com/livekit/track-processors-js/blob/3920c38b280accbd26152324bfd9298cc27949a9/src/transformers/BackgroundTransformer.ts#L105-L160) gets called, and execution starts.
3. [This `segmentPromise` line](https://github.com/livekit/track-processors-js/blob/3920c38b280accbd26152324bfd9298cc27949a9/src/transformers/BackgroundTransformer.ts#L122-L135) gets hit, which _seems_ like from the way the code was written should be async, but is actually synchronous, so execution halts for tens+ of milliseconds.
  a. Importantly, the promise isn't being `await`ed here, but that doesn't actually matter - `new Promise` kicks off the callback immediately no matter what.
  b. Because this is blocking the event loop, it grinds the rest of the page to a halt - importantly, actually blocking rendering of other frames / etc to the screen as well!
4. [This `drawFrame` call](https://github.com/livekit/track-processors-js/blob/3920c38b280accbd26152324bfd9298cc27949a9/src/transformers/BackgroundTransformer.ts#L138) occurs and also blocks the event loop for some time while it issues a bunch of webgl commands.
5. Finally, `controller.enqueue(frame)` [here](https://github.com/livekit/track-processors-js/blob/3920c38b280accbd26152324bfd9298cc27949a9/src/transformers/BackgroundTransformer.ts#L143) is hit, and the frame is passed along to infrastructure further down the line, and the gray state goes away.

## Solution / Workaround
I think ideally, all these relatively long-running (at least in a graphics rendering context) synchronous functions would be offloaded to something like a webworker, but this proved to be challenging since webgl objects can't be passed around via a `postMessage`.

To work around the problem, I've opted to send along the first frame unprocessed to get rid of the "gray state", which makes it less obvious, sort of [similar to how ios uses a splash image](https://developer.apple.com/documentation/xcode/specifying-your-apps-launch-screen) to cover up initial app loading. 

What this looks like in practice:
1. (same as above - media stack is constructed)
2. (same as above - `transform` called for the first time)
3. On the first call of `transform`, `isFirstFrame` is `true`, which goes down a special first-frame-only path:
  a. Enqueue the **unprocessed** frame, directly from the input
  b. Wait for the browser to paint that frame to the screen before continuing
4. The initial unprocessed frame is shown, clearing the "gray state" now that there is a frame available to render
5. Segmentation, `drawFrame`, etc are performed - these sync operations still block the event loop, but now because of the brief pause in `3b`, they don't block rendering
6. `controller.enqueue(frame)` is called, and a processed frame is sent along

It's also worth mentioning that this approach still doesn't 100% fix the issue - there's some delay at the start of the media pipeline that it seems is inevitable given the abstractions that exist right now. This maybe is something to consider doing better as part of a future refactor.

## Testing
This is obviously a substantial change, and probably needs some testing. I've tested on chrome, safari, and firefox on my macbook pro with success - videos below:

Chrome:

https://github.com/user-attachments/assets/7f6f2a19-55e0-4062-bfa4-d0f82095fb44


Safari:

https://github.com/user-attachments/assets/49f251b5-d22e-44ea-bba5-1e8bd490caec


Firefox:

https://github.com/user-attachments/assets/389f4d8c-e866-4333-a326-f3d9a389e377
