### PR TITLE
fix: don't fail without radius/background image

### DIFF
--- a/.changeset/fast-roses-heal.md
+++ b/.changeset/fast-roses-heal.md
@@ -1,0 +1,5 @@
+---
+'@livekit/track-processors': minor
+---
+
+Faster disabling of background transformers

--- a/src/transformers/BackgroundTransformer.ts
+++ b/src/transformers/BackgroundTransformer.ts
@@ -116,7 +116,12 @@ export default class BackgroundProcessor extends VideoTransformer<BackgroundOpti
         return;
       }
 
-      if (this.isDisabled) {
+      let disabled = this.isDisabled ?? false;
+      if (this.options.blurRadius === null && this.options.imagePath === null) {
+        disabled = true;
+      }
+
+      if (disabled) {
         controller.enqueue(frame);
         enqueuedFrame = true;
         return;


### PR DESCRIPTION
This PR enables faster enabling/disabling of video processing by just passing through a frame if no blur options are set.
The update is instantaneous without flickering or delay as opposed to fully disabling/enabling the track processor