### PR TITLE
Add logic to BackgroundProcessor to allow dynamically switching modes elegantly, and deprecate pre-existing interfaces

### DIFF
--- a/.changeset/shaky-crews-bake.md
+++ b/.changeset/shaky-crews-bake.md
@@ -1,0 +1,5 @@
+---
+'@livekit/track-processors': patch
+---
+
+Add logic to BackgroundProcessor to allow dynamically switching modes elegantly

--- a/example/index.html
+++ b/example/index.html
@@ -98,24 +98,13 @@
               <div class="card mt-1 mb-1 mx-n2 p-2">
                 <div>
                   <button
-                    id="insert-track-processor"
+                    id="toggle-track-processor"
                     class="btn btn-secondary"
                     disabled
                     type="button"
                     onclick="appActions.toggleTrackProcessorEnabled()"
                   >
                     Insert Track Processor
-                  </button>
-
-                  <button
-                    id="remove-track-processor"
-                    class="btn btn-secondary"
-                    disabled
-                    type="button"
-                    onclick="appActions.toggleTrackProcessorEnabled()"
-                    style="display: none;"
-                  >
-                    Remove Track Processor
                   </button>
                 </div>
 

--- a/example/index.html
+++ b/example/index.html
@@ -66,6 +66,35 @@
                 Enable Camera
               </button>
 
+              <button
+                id="flip-video-button"
+                class="btn btn-secondary mt-1"
+                type="button"
+                onclick="appActions.flipVideo()"
+              >
+                Flip Video
+              </button>
+
+              <button
+                id="disconnect-room-button"
+                class="btn btn-danger mt-1"
+                disabled
+                type="button"
+                onclick="appActions.disconnectRoom()"
+              >
+                Disconnect
+              </button>
+
+              <button
+                id="start-audio-button"
+                class="btn btn-secondary mt-1"
+                disabled
+                type="button"
+                onclick="appActions.startAudio()"
+              >
+                Start Audio
+              </button>
+
               <div class="card mt-1 mb-1 mx-n2 p-2">
                 <div>
                   <button
@@ -91,7 +120,7 @@
                 </div>
 
                 <div id="track-processor-modes" style="display: none;">
-                  <div class="btn-group mt-2">
+                  <div class="btn-group mt-1">
                     <button
                       id="switch-to-disabled-button"
                       class="btn btn-secondary"
@@ -132,34 +161,6 @@
                   </button>
                 </div>
               </div>
-
-              <button
-                id="flip-video-button"
-                class="btn btn-secondary mt-1"
-                type="button"
-                onclick="appActions.flipVideo()"
-              >
-                Flip Video
-              </button>
-
-              <button
-                id="disconnect-room-button"
-                class="btn btn-danger mt-1"
-                disabled
-                type="button"
-                onclick="appActions.disconnectRoom()"
-              >
-                Disconnect
-              </button>
-              <button
-                id="start-audio-button"
-                class="btn btn-secondary mt-1"
-                disabled
-                type="button"
-                onclick="appActions.startAudio()"
-              >
-                Start Audio
-              </button>
             </div>
           </div>
 

--- a/example/index.html
+++ b/example/index.html
@@ -65,33 +65,62 @@
               >
                 Enable Camera
               </button>
-              <button
-                id="toggle-blur-button"
-                class="btn btn-secondary mt-1"
-                disabled
-                type="button"
-                onclick="appActions.toggleBlur()"
-              >
-                Toggle BackgroundBlur
-              </button>
-              <button
-                id="toggle-virtual-bg-button"
-                class="btn btn-secondary mt-1"
-                disabled
-                type="button"
-                onclick="appActions.toggleVirtualBackground()"
-              >
-                Toggle virtual background
-              </button>
-              <button
-                id="toggle-disabled-bg-button"
-                class="btn btn-secondary mt-1"
-                disabled
-                type="button"
-                onclick="appActions.toggleDisabledBackground()"
-              >
-                Toggle disabled background
-              </button>
+
+              <div class="card mt-1 mb-1 mx-n2 p-2">
+                <div>
+                  <button
+                    id="insert-track-processor"
+                    class="btn btn-secondary"
+                    disabled
+                    type="button"
+                    onclick="appActions.toggleTrackProcessorEnabled()"
+                  >
+                    Insert Track Processor
+                  </button>
+
+                  <button
+                    id="remove-track-processor"
+                    class="btn btn-secondary"
+                    disabled
+                    type="button"
+                    onclick="appActions.toggleTrackProcessorEnabled()"
+                    style="display: none;"
+                  >
+                    Remove Track Processor
+                  </button>
+                </div>
+
+                <div class="btn-group mt-2" id="track-processor-modes" style="display: none;">
+                  <button
+                    id="toggle-disabled-button"
+                    class="btn btn-secondary"
+                    disabled
+                    type="button"
+                    onclick="appActions.toggleDisabledBackground()"
+                  >
+                    Disabled
+                  </button>
+                  <button
+                    id="toggle-blur-button"
+                    class="btn btn-secondary"
+                    disabled
+                    type="button"
+                    onclick="appActions.toggleBlur()"
+                  >
+                    Blur
+                  </button>
+                  <button
+                    id="toggle-virtual-bg-button"
+                    class="btn btn-secondary"
+                    disabled
+                    type="button"
+                    onclick="appActions.toggleVirtualBackground()"
+                  >
+                    Virtual background
+                  </button>
+                </div>
+              </div>
+
               <button
                 id="flip-video-button"
                 class="btn btn-secondary mt-1"
@@ -113,6 +142,7 @@
               <button
                 id="update-bg-button"
                 class="btn btn-secondary mt-1"
+                disabled
                 type="button"
                 onclick="appActions.updateVirtualBackgroundImage('/ali-kazal-tbw_KQE3Cbg-unsplash.jpg')"
               >

--- a/example/index.html
+++ b/example/index.html
@@ -92,29 +92,29 @@
 
                 <div class="btn-group mt-2" id="track-processor-modes" style="display: none;">
                   <button
-                    id="toggle-disabled-button"
+                    id="switch-to-disabled-button"
                     class="btn btn-secondary"
                     disabled
                     type="button"
-                    onclick="appActions.toggleDisabledBackground()"
+                    onclick="appActions.switchBackgroundMode('disabled')"
                   >
                     Disabled
                   </button>
                   <button
-                    id="toggle-blur-button"
+                    id="switch-to-background-blur-button"
                     class="btn btn-secondary"
                     disabled
                     type="button"
-                    onclick="appActions.toggleBlur()"
+                    onclick="appActions.switchBackgroundMode('background-blur')"
                   >
                     Blur
                   </button>
                   <button
-                    id="toggle-virtual-bg-button"
+                    id="switch-to-virtual-background-button"
                     class="btn btn-secondary"
                     disabled
                     type="button"
-                    onclick="appActions.toggleVirtualBackground()"
+                    onclick="appActions.switchBackgroundMode('virtual-background')"
                   >
                     Virtual background
                   </button>

--- a/example/index.html
+++ b/example/index.html
@@ -84,6 +84,15 @@
                 Toggle virtual background
               </button>
               <button
+                id="toggle-disabled-bg-button"
+                class="btn btn-secondary mt-1"
+                disabled
+                type="button"
+                onclick="appActions.toggleDisabledBackground()"
+              >
+                Toggle disabled background
+              </button>
+              <button
                 id="flip-video-button"
                 class="btn btn-secondary mt-1"
                 type="button"

--- a/example/index.html
+++ b/example/index.html
@@ -90,33 +90,45 @@
                   </button>
                 </div>
 
-                <div class="btn-group mt-2" id="track-processor-modes" style="display: none;">
+                <div id="track-processor-modes" style="display: none;">
+                  <div class="btn-group mt-2">
+                    <button
+                      id="switch-to-disabled-button"
+                      class="btn btn-secondary"
+                      disabled
+                      type="button"
+                      onclick="appActions.switchBackgroundMode('disabled')"
+                    >
+                      Disabled
+                    </button>
+                    <button
+                      id="switch-to-background-blur-button"
+                      class="btn btn-secondary"
+                      disabled
+                      type="button"
+                      onclick="appActions.switchBackgroundMode('background-blur')"
+                    >
+                      Blur
+                    </button>
+                    <button
+                      id="switch-to-virtual-background-button"
+                      class="btn btn-secondary"
+                      disabled
+                      type="button"
+                      onclick="appActions.switchBackgroundMode('virtual-background')"
+                    >
+                      Virtual background
+                    </button>
+                  </div>
+
                   <button
-                    id="switch-to-disabled-button"
-                    class="btn btn-secondary"
+                    id="update-bg-button"
+                    class="btn btn-secondary mt-1"
                     disabled
                     type="button"
-                    onclick="appActions.switchBackgroundMode('disabled')"
+                    onclick="appActions.updateVirtualBackgroundImage('/ali-kazal-tbw_KQE3Cbg-unsplash.jpg')"
                   >
-                    Disabled
-                  </button>
-                  <button
-                    id="switch-to-background-blur-button"
-                    class="btn btn-secondary"
-                    disabled
-                    type="button"
-                    onclick="appActions.switchBackgroundMode('background-blur')"
-                  >
-                    Blur
-                  </button>
-                  <button
-                    id="switch-to-virtual-background-button"
-                    class="btn btn-secondary"
-                    disabled
-                    type="button"
-                    onclick="appActions.switchBackgroundMode('virtual-background')"
-                  >
-                    Virtual background
+                    Update Background Image
                   </button>
                 </div>
               </div>
@@ -128,25 +140,6 @@
                 onclick="appActions.flipVideo()"
               >
                 Flip Video
-              </button>
-
-              <button
-                id="toggle-virtual-bg-button"
-                class="btn btn-secondary mt-1"
-                disabled
-                type="button"
-                onclick="appActions.toggleVirtualBackground()"
-              >
-                Toggle Background
-              </button>
-              <button
-                id="update-bg-button"
-                class="btn btn-secondary mt-1"
-                disabled
-                type="button"
-                onclick="appActions.updateVirtualBackgroundImage('/ali-kazal-tbw_KQE3Cbg-unsplash.jpg')"
-              >
-                Update Background Image
               </button>
 
               <button

--- a/example/sample.ts
+++ b/example/sample.ts
@@ -271,100 +271,36 @@ const appActions = {
     }
   },
 
-  toggleBlur: async () => {
+  switchBackgroundMode: async (newMode: NonNullable<BackgroundProcessorOptions['mode']>) => {
     if (!currentRoom) return;
-    setButtonDisabled('toggle-blur-button', true);
+
+    const controlButtonId = `switch-to-${newMode}-button`;
+    setButtonDisabled(controlButtonId, true);
 
     try {
       const camTrack = currentRoom.localParticipant.getTrackPublication(Track.Source.Camera)!
         .track as LocalVideoTrack;
-      switch (state.backgroundMode) {
-        case 'background-blur':
-          break;
 
+      switch (newMode) {
         case 'disabled':
-        case 'virtual-background':
-          await state.backgroundProcessor.switchToBackgroundBlur(BLUR_RADIUS);
-          state.backgroundMode = 'background-blur';
-          break;
-
-        case null:
-        default:
-          await state.backgroundProcessor.switchToBackgroundBlur(BLUR_RADIUS);
-          await camTrack.setProcessor(state.backgroundProcessor);
-          state.backgroundMode = 'background-blur';
-          break;
-      }
-    } catch (e: any) {
-      appendLog(`ERROR: ${e.message}`);
-    } finally {
-      setButtonDisabled('toggle-blur-button', false);
-      renderParticipant(currentRoom.localParticipant);
-      updateButtonsForPublishState();
-      updateTrackProcessorModeButtons();
-    }
-  },
-
-  toggleDisabledBackground: async () => {
-    if (!currentRoom) return;
-    setButtonDisabled('toggle-disabled-button', true);
-    try {
-      const camTrack = currentRoom.localParticipant.getTrackPublication(Track.Source.Camera)!
-        .track as LocalVideoTrack;
-      switch (state.backgroundMode) {
-        case 'disabled':
-          break;
-
-        case 'virtual-background':
-        case 'background-blur':
           await state.backgroundProcessor.switchToDisabled();
-          state.backgroundMode = 'disabled';
           break;
-
-        case null:
-        default:
-          await state.backgroundProcessor.switchToDisabled();
-          await camTrack.setProcessor(state.backgroundProcessor);
-          state.backgroundMode = 'disabled';
-          break;
-      }
-    } catch (e: any) {
-      appendLog(`ERROR: ${e.message}`);
-    } finally {
-      setButtonDisabled('toggle-disabled-button', false);
-      renderParticipant(currentRoom.localParticipant);
-      updateButtonsForPublishState();
-      updateTrackProcessorModeButtons();
-    }
-  },
-
-  toggleVirtualBackground: async () => {
-    if (!currentRoom) return;
-    setButtonDisabled('toggle-virtual-bg-button', true);
-    try {
-      const camTrack = currentRoom.localParticipant.getTrackPublication(Track.Source.Camera)!
-        .track as LocalVideoTrack;
-      switch (state.backgroundMode) {
         case 'virtual-background':
+          await state.backgroundProcessor.switchToVirtualBackground(IMAGE_PATH);
           break;
-
-        case 'disabled':
         case 'background-blur':
-          await state.backgroundProcessor.switchToVirtualBackground(IMAGE_PATH);
-          state.backgroundMode = 'virtual-background';
-          break;
-
-        case null:
-        default:
-          await state.backgroundProcessor.switchToVirtualBackground(IMAGE_PATH);
-          await camTrack.setProcessor(state.backgroundProcessor);
-          state.backgroundMode = 'virtual-background';
+          await state.backgroundProcessor.switchToBackgroundBlur(BLUR_RADIUS);
           break;
       }
+
+      if (state.backgroundMode === null) {
+        await camTrack.setProcessor(state.backgroundProcessor);
+      }
+      state.backgroundMode = newMode;
     } catch (e: any) {
       appendLog(`ERROR: ${e.message}`);
     } finally {
-      setButtonDisabled('toggle-virtual-bg-button', false);
+      setButtonDisabled(controlButtonId, false);
       renderParticipant(currentRoom.localParticipant);
       updateButtonsForPublishState();
       updateTrackProcessorModeButtons();
@@ -385,7 +321,7 @@ const appActions = {
     } catch (e: any) {
       appendLog(`ERROR: ${e.message}`);
     } finally {
-      setButtonDisabled('toggle-blur-button', false);
+      setButtonDisabled('switch-to-background-blur-button', false);
       renderParticipant(currentRoom.localParticipant);
       updateButtonsForPublishState();
     }
@@ -712,9 +648,9 @@ function setButtonsForState(connected: boolean) {
     'disconnect-room-button',
     'insert-track-processor',
     'remove-track-processor',
-    'toggle-blur-button',
-    'toggle-virtual-bg-button',
-    'toggle-disabled-button',
+    'switch-to-background-blur-button',
+    'switch-to-virtual-background-button',
+    'switch-to-disabled-button',
   ];
   const disconnectedSet = ['connect-button'];
 
@@ -797,9 +733,9 @@ function updateTrackProcessorModeButtons() {
   }
 
   const {active: activeButtonId, inactive: inactiveButtonIds} = {
-    'disabled': { active: 'toggle-disabled-button', inactive: ['toggle-virtual-bg-button', 'toggle-blur-button'] },
-    'virtual-background': { active: 'toggle-virtual-bg-button', inactive: ['toggle-disabled-button', 'toggle-blur-button'] },
-    'background-blur': { active: 'toggle-blur-button', inactive: ['toggle-virtual-bg-button', 'toggle-disabled-button'] },
+    'disabled': { active: 'switch-to-disabled-button', inactive: ['switch-to-virtual-background-button', 'switch-to-background-blur-button'] },
+    'virtual-background': { active: 'switch-to-virtual-background-button', inactive: ['switch-to-disabled-button', 'switch-to-background-blur-button'] },
+    'background-blur': { active: 'switch-to-background-blur-button', inactive: ['switch-to-virtual-background-button', 'switch-to-disabled-button'] },
     'off': { active: null, inactive: [] },
   }[state.backgroundMode ?? 'off'];
 

--- a/example/sample.ts
+++ b/example/sample.ts
@@ -352,7 +352,7 @@ const appActions = {
       const camTrack = currentRoom.localParticipant.getTrackPublication(Track.Source.Camera)!
         .track as LocalVideoTrack;
       await state.background.switchToVirtualBackground(imagePath);
-      if (state.backgroundMode !== null) {
+      if (state.backgroundMode === null) {
         await camTrack.stopProcessor();
         await camTrack.setProcessor(state.background);
       }

--- a/example/sample.ts
+++ b/example/sample.ts
@@ -245,8 +245,7 @@ const appActions = {
   toggleTrackProcessorEnabled: async () => {
     if (!currentRoom) return;
 
-    setButtonDisabled('insert-track-processor', true);
-    setButtonDisabled('remove-track-processor', true);
+    setButtonDisabled('toggle-track-processor', true);
 
     try {
       const camTrack = currentRoom.localParticipant.getTrackPublication(Track.Source.Camera)!
@@ -263,8 +262,6 @@ const appActions = {
     } catch (e: any) {
       appendLog(`ERROR: ${e.message}`);
     } finally {
-      setButtonDisabled('insert-track-processor', false);
-      setButtonDisabled('remove-track-processor', false);
       renderParticipant(currentRoom.localParticipant);
       updateButtonsForPublishState();
       updateTrackProcessorModeButtons();
@@ -646,8 +643,7 @@ function setButtonsForState(connected: boolean) {
     'toggle-video-button',
     'toggle-audio-button',
     'disconnect-room-button',
-    'insert-track-processor',
-    'remove-track-processor',
+    'toggle-track-processor',
     'switch-to-background-blur-button',
     'switch-to-virtual-background-button',
     'switch-to-disabled-button',
@@ -721,14 +717,10 @@ function updateButtonsForPublishState() {
 
 function updateTrackProcessorModeButtons() {
   if (state.isBackgroundProcessorEnabled) {
-    $('insert-track-processor').style.display = 'none';
-    $('remove-track-processor').style.display = 'block';
-
+    setButtonState('toggle-track-processor', 'Remove Track Processor', false, false);
     $('track-processor-modes').style.display = 'block';
   } else {
-    $('insert-track-processor').style.display = 'block';
-    $('remove-track-processor').style.display = 'none';
-
+    setButtonState('toggle-track-processor', 'Insert Track Processor', false, false);
     $('track-processor-modes').style.display = 'none';
   }
 

--- a/example/sample.ts
+++ b/example/sample.ts
@@ -35,7 +35,7 @@ const state = {
   defaultDevices: new Map<MediaDeviceKind, string>(),
   bitrateInterval: undefined as any,
   backgroundMode: null as NonNullable<BackgroundProcessorOptions['mode']> | null,
-  background: BackgroundProcessor({ mode: 'background-blur', blurRadius: BLUR_RADIUS }),
+  backgroundProcessor: BackgroundProcessor({ mode: 'background-blur', blurRadius: BLUR_RADIUS }),
 };
 let currentRoom: Room | undefined;
 
@@ -253,9 +253,9 @@ const appActions = {
         .track as LocalVideoTrack;
 
       if (state.backgroundMode === null) {
-        await state.background.switchToDisabled();
+        await state.backgroundProcessor.switchToDisabled();
         state.backgroundMode = 'disabled';
-        await camTrack.setProcessor(state.background);
+        await camTrack.setProcessor(state.backgroundProcessor);
       } else {
         await camTrack.stopProcessor();
         state.backgroundMode = null;
@@ -284,14 +284,14 @@ const appActions = {
 
         case 'disabled':
         case 'virtual-background':
-          await state.background.switchToBackgroundBlur(BLUR_RADIUS);
+          await state.backgroundProcessor.switchToBackgroundBlur(BLUR_RADIUS);
           state.backgroundMode = 'background-blur';
           break;
 
         case null:
         default:
-          await state.background.switchToBackgroundBlur(BLUR_RADIUS);
-          await camTrack.setProcessor(state.background);
+          await state.backgroundProcessor.switchToBackgroundBlur(BLUR_RADIUS);
+          await camTrack.setProcessor(state.backgroundProcessor);
           state.backgroundMode = 'background-blur';
           break;
       }
@@ -317,14 +317,14 @@ const appActions = {
 
         case 'virtual-background':
         case 'background-blur':
-          await state.background.switchToDisabled();
+          await state.backgroundProcessor.switchToDisabled();
           state.backgroundMode = 'disabled';
           break;
 
         case null:
         default:
-          await state.background.switchToDisabled();
-          await camTrack.setProcessor(state.background);
+          await state.backgroundProcessor.switchToDisabled();
+          await camTrack.setProcessor(state.backgroundProcessor);
           state.backgroundMode = 'disabled';
           break;
       }
@@ -350,14 +350,14 @@ const appActions = {
 
         case 'disabled':
         case 'background-blur':
-          await state.background.switchToVirtualBackground(IMAGE_PATH);
+          await state.backgroundProcessor.switchToVirtualBackground(IMAGE_PATH);
           state.backgroundMode = 'virtual-background';
           break;
 
         case null:
         default:
-          await state.background.switchToVirtualBackground(IMAGE_PATH);
-          await camTrack.setProcessor(state.background);
+          await state.backgroundProcessor.switchToVirtualBackground(IMAGE_PATH);
+          await camTrack.setProcessor(state.backgroundProcessor);
           state.backgroundMode = 'virtual-background';
           break;
       }
@@ -377,10 +377,10 @@ const appActions = {
     try {
       const camTrack = currentRoom.localParticipant.getTrackPublication(Track.Source.Camera)!
         .track as LocalVideoTrack;
-      await state.background.switchToVirtualBackground(imagePath);
+      await state.backgroundProcessor.switchToVirtualBackground(imagePath);
       if (state.backgroundMode === null) {
         await camTrack.stopProcessor();
-        await camTrack.setProcessor(state.background);
+        await camTrack.setProcessor(state.backgroundProcessor);
       }
     } catch (e: any) {
       appendLog(`ERROR: ${e.message}`);

--- a/example/sample.ts
+++ b/example/sample.ts
@@ -255,7 +255,7 @@ const appActions = {
         await camTrack.stopProcessor();
         state.isBackgroundProcessorEnabled = false;
       } else {
-        await state.backgroundProcessor.switchToDisabled();
+        await state.backgroundProcessor.switchTo({ mode: 'disabled' });
         state.isBackgroundProcessorEnabled = true;
         await camTrack.setProcessor(state.backgroundProcessor);
       }
@@ -280,13 +280,13 @@ const appActions = {
 
       switch (newMode) {
         case 'disabled':
-          await state.backgroundProcessor.switchToDisabled();
+          await state.backgroundProcessor.switchTo({ mode: 'disabled' });
           break;
         case 'virtual-background':
-          await state.backgroundProcessor.switchToVirtualBackground(IMAGE_PATH);
+          await state.backgroundProcessor.switchTo({ mode: 'virtual-background', imagePath: IMAGE_PATH });
           break;
         case 'background-blur':
-          await state.backgroundProcessor.switchToBackgroundBlur(BLUR_RADIUS);
+          await state.backgroundProcessor.switchTo({ mode: 'background-blur' });
           break;
       }
 
@@ -310,7 +310,7 @@ const appActions = {
     try {
       const camTrack = currentRoom.localParticipant.getTrackPublication(Track.Source.Camera)!
         .track as LocalVideoTrack;
-      await state.backgroundProcessor.switchToVirtualBackground(imagePath);
+      await state.backgroundProcessor.switchTo({ mode: 'virtual-background', imagePath });
       if (!state.isBackgroundProcessorEnabled) {
         await camTrack.stopProcessor();
         await camTrack.setProcessor(state.backgroundProcessor);

--- a/src/ProcessorWrapper.ts
+++ b/src/ProcessorWrapper.ts
@@ -11,7 +11,10 @@ export interface ProcessorWrapperOptions {
   maxFps?: number;
 }
 
-export default class ProcessorWrapper<TransformerOptions extends Record<string, unknown>>
+export default class ProcessorWrapper<
+  TransformerOptions extends Record<string, unknown>,
+  Transformer extends TrackTransformer<TransformerOptions> = TrackTransformer<TransformerOptions>,
+>
   implements TrackProcessor<Track.Kind>
 {
   /**
@@ -59,7 +62,7 @@ export default class ProcessorWrapper<TransformerOptions extends Record<string, 
 
   processedTrack?: MediaStreamTrack;
 
-  transformer: TrackTransformer<TransformerOptions>;
+  transformer: Transformer;
 
   // For tracking whether we're using the stream API fallback
   private useStreamFallback = false;
@@ -83,7 +86,7 @@ export default class ProcessorWrapper<TransformerOptions extends Record<string, 
   private log = getLogger(LoggerNames.ProcessorWrapper);
 
   constructor(
-    transformer: TrackTransformer<TransformerOptions>,
+    transformer: Transformer,
     name: string,
     options: ProcessorWrapperOptions = {},
   ) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,8 @@ export const supportsModernBackgroundProcessors = () =>
 
 type SwitchBackgroundProcessorBackgroundBlurOptions = {
   mode: 'background-blur';
-  blurRadius: number;
+  /** If unspecified, defaults to {@link DEFAULT_BLUR_RADIUS} */
+  blurRadius?: number;
 };
 
 type SwitchBackgroundProcessorVirtualBackgroundOptions = {
@@ -78,7 +79,7 @@ class BackgroundProcessorWrapper extends ProcessorWrapper<BackgroundOptions, Bac
       return 'virtual-background';
     }
 
-    if (typeof options.imagePath === 'undefined' && typeof options.blurRadius === 'number') {
+    if (typeof options.imagePath === 'undefined') {
       return 'background-blur';
     }
 
@@ -88,10 +89,18 @@ class BackgroundProcessorWrapper extends ProcessorWrapper<BackgroundOptions, Bac
   async switchToMode(options: SwitchBackgroundProcessorOptions) {
     switch (options.mode) {
       case 'background-blur':
-        await this.updateTransformerOptions({ imagePath: undefined, blurRadius: options.blurRadius, backgroundDisabled: false });
+        await this.updateTransformerOptions({
+          imagePath: undefined,
+          blurRadius: options.blurRadius ?? DEFAULT_BLUR_RADIUS,
+          backgroundDisabled: false,
+        });
         break;
       case 'virtual-background':
-        await this.updateTransformerOptions({ imagePath: options.imagePath, blurRadius: undefined, backgroundDisabled: false });
+        await this.updateTransformerOptions({
+          imagePath: options.imagePath,
+          blurRadius: undefined,
+          backgroundDisabled: false,
+        });
         break;
       case 'disabled':
         await this.updateTransformerOptions({ imagePath: undefined, backgroundDisabled: true });
@@ -151,7 +160,7 @@ export const BackgroundProcessor = (
       const {
         // eslint-disable-next-line no-unused-vars
         mode,
-        blurRadius,
+        blurRadius = DEFAULT_BLUR_RADIUS,
         segmenterOptions,
         assetPaths,
         onFrameProcessed,

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,10 @@ type BackgroundProcessorVirtualBackgroundOptions = BackgroundProcessorCommonOpti
   imagePath: string;
 };
 
+type BackgroundProcessorDisabledOptions = BackgroundProcessorCommonOptions & {
+  mode: 'disabled';
+};
+
 type BackgroundProcessorLegacyOptions = BackgroundProcessorCommonOptions & {
   mode?: never;
   blurRadius?: number;
@@ -53,6 +57,7 @@ type BackgroundProcessorLegacyOptions = BackgroundProcessorCommonOptions & {
 };
 
 export type BackgroundProcessorOptions =
+| BackgroundProcessorDisabledOptions
 | BackgroundProcessorBackgroundBlurOptions
 | BackgroundProcessorVirtualBackgroundOptions
 | BackgroundProcessorLegacyOptions;
@@ -63,6 +68,9 @@ class BackgroundProcessorWrapper extends ProcessorWrapper<BackgroundOptions> {
   }
   async switchToVirtualBackground(imagePath: string) {
     await this.updateTransformerOptions({ imagePath, blurRadius: undefined });
+  }
+  async switchToDisabled() {
+    await this.updateTransformerOptions({ imagePath: undefined, blurRadius: 0, backgroundDisabled: true });
   }
 }
 
@@ -134,6 +142,23 @@ export const BackgroundProcessor = (
       processorOpts = rest;
       transformer = new BackgroundTransformer({
         imagePath,
+        segmenterOptions,
+        assetPaths,
+        onFrameProcessed,
+      });
+      break;
+    }
+
+    case 'disabled': {
+      const {
+        segmenterOptions,
+        assetPaths,
+        onFrameProcessed,
+        ...rest
+      } = options;
+
+      processorOpts = rest;
+      transformer = new BackgroundTransformer({
         segmenterOptions,
         assetPaths,
         onFrameProcessed,

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,9 +66,11 @@ class BackgroundProcessorWrapper extends ProcessorWrapper<BackgroundOptions> {
   async switchToBackgroundBlur(blurRadius: number = DEFAULT_BLUR_RADIUS) {
     await this.updateTransformerOptions({ imagePath: undefined, blurRadius, backgroundDisabled: false });
   }
+
   async switchToVirtualBackground(imagePath: string) {
     await this.updateTransformerOptions({ imagePath, blurRadius: undefined, backgroundDisabled: false });
   }
+
   async switchToDisabled() {
     await this.updateTransformerOptions({ imagePath: undefined, backgroundDisabled: true });
   }
@@ -111,7 +113,8 @@ export const BackgroundProcessor = (
   switch (options.mode) {
     case 'background-blur': {
       const {
-        mode: _mode,
+        // eslint-disable-next-line no-unused-vars
+        mode,
         blurRadius,
         segmenterOptions,
         assetPaths,
@@ -131,7 +134,8 @@ export const BackgroundProcessor = (
 
     case 'virtual-background': {
       const {
-        mode: _mode,
+        // eslint-disable-next-line no-unused-vars
+        mode,
         imagePath,
         segmenterOptions,
         assetPaths,

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,13 +64,13 @@ export type BackgroundProcessorOptions =
 
 class BackgroundProcessorWrapper extends ProcessorWrapper<BackgroundOptions> {
   async switchToBackgroundBlur(blurRadius: number = DEFAULT_BLUR_RADIUS) {
-    await this.updateTransformerOptions({ imagePath: undefined, blurRadius });
+    await this.updateTransformerOptions({ imagePath: undefined, blurRadius, backgroundDisabled: false });
   }
   async switchToVirtualBackground(imagePath: string) {
-    await this.updateTransformerOptions({ imagePath, blurRadius: undefined });
+    await this.updateTransformerOptions({ imagePath, blurRadius: undefined, backgroundDisabled: false });
   }
   async switchToDisabled() {
-    await this.updateTransformerOptions({ imagePath: undefined, blurRadius: 0, backgroundDisabled: true });
+    await this.updateTransformerOptions({ imagePath: undefined, backgroundDisabled: true });
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,7 @@ class BackgroundProcessorWrapper extends ProcessorWrapper<BackgroundOptions, Bac
     return 'legacy';
   }
 
-  async switchToMode(options: SwitchBackgroundProcessorOptions) {
+  async switchTo(options: SwitchBackgroundProcessorOptions) {
     switch (options.mode) {
       case 'background-blur':
         await this.updateTransformerOptions({
@@ -106,18 +106,6 @@ class BackgroundProcessorWrapper extends ProcessorWrapper<BackgroundOptions, Bac
         await this.updateTransformerOptions({ imagePath: undefined, backgroundDisabled: true });
         break;
     }
-  }
-
-  async switchToBackgroundBlur(blurRadius: number = DEFAULT_BLUR_RADIUS) {
-    await this.switchToMode({ mode: 'background-blur', blurRadius });
-  }
-
-  async switchToVirtualBackground(imagePath: string) {
-    await this.switchToMode({ mode: 'virtual-background', imagePath });
-  }
-
-  async switchToDisabled() {
-    await this.switchToMode({ mode: 'disabled' });
   }
 }
 

--- a/src/transformers/BackgroundTransformer.ts
+++ b/src/transformers/BackgroundTransformer.ts
@@ -121,12 +121,12 @@ export default class BackgroundProcessor extends VideoTransformer<BackgroundOpti
         return;
       }
 
-      let disabled = this.isDisabled ?? false;
-      if (this.options.blurRadius === null && this.options.imagePath === null) {
-        disabled = true;
+      let skipProcessingFrame = this.isDisabled ?? this.options.backgroundDisabled ?? false;
+      if (typeof this.options.blurRadius !== 'number' && typeof this.options.imagePath !== 'string') {
+        skipProcessingFrame = true;
       }
 
-      if (disabled) {
+      if (skipProcessingFrame) {
         controller.enqueue(frame);
         enqueuedFrame = true;
         return;

--- a/src/transformers/BackgroundTransformer.ts
+++ b/src/transformers/BackgroundTransformer.ts
@@ -15,6 +15,7 @@ export interface FrameProcessingStats {
 export type BackgroundOptions = {
   blurRadius?: number;
   imagePath?: string;
+  backgroundDisabled?: boolean;
   /** cannot be updated through the `update` method, needs a restart */
   segmenterOptions?: SegmenterOptions;
   /** cannot be updated through the `update` method, needs a restart */
@@ -83,9 +84,10 @@ export default class BackgroundProcessor extends VideoTransformer<BackgroundOpti
         this.log.error('Error while loading processor background image: ', err),
       );
     }
-    if (this.options.blurRadius) {
+    if (typeof this.options.blurRadius === 'number') {
       this.gl?.setBlurRadius(this.options.blurRadius);
     }
+    this.gl?.setBackgroundDisabled(this.options.backgroundDisabled ?? false);
   }
 
   async destroy() {
@@ -215,6 +217,7 @@ export default class BackgroundProcessor extends VideoTransformer<BackgroundOpti
     } else {
       this.gl?.setBackgroundImage(null);
     }
+    this.gl?.setBackgroundDisabled(opts.backgroundDisabled ?? false);
   }
 
   private async drawFrame(frame: VideoFrame) {

--- a/src/transformers/VideoTransformer.ts
+++ b/src/transformers/VideoTransformer.ts
@@ -15,7 +15,7 @@ export default abstract class VideoTransformer<Options extends Record<string, un
 
   gl?: ReturnType<typeof setupWebGL>;
 
-  protected isDisabled?: Boolean = false;
+  protected isDisabled?: boolean = false;
 
   async init({
     outputCanvas,

--- a/src/webgl/index.ts
+++ b/src/webgl/index.ts
@@ -45,6 +45,7 @@ export const setupWebGL = (canvas: OffscreenCanvas | HTMLCanvasElement) => {
     mask: maskTextureLocation,
     frame: frameTextureLocation,
     background: bgTextureLocation,
+    disableBackground: disableBackgroundLocation,
   } = composite.uniformLocations;
 
   // Create the blur program using the same vertex shader source
@@ -106,14 +107,17 @@ export const setupWebGL = (canvas: OffscreenCanvas | HTMLCanvasElement) => {
     createFramebuffer(gl, finalMaskTextures[1], canvas.width, canvas.height),
   ];
 
+  let backgroundImageDisabled = false;
+
   // Set up uniforms for the composite shader
   gl.useProgram(compositeProgram);
+  gl.uniform1i(disableBackgroundLocation, backgroundImageDisabled ? 1 : 0);
   gl.uniform1i(bgTextureLocation, 0);
   gl.uniform1i(frameTextureLocation, 1);
   gl.uniform1i(maskTextureLocation, 2);
 
   // Store custom background image
-  let customBackgroundImage: ImageBitmap | ImageData = getEmptyImageData();
+  let customBackgroundImage: ImageBitmap | ImageData | null = null;
 
   function renderFrame(frame: VideoFrame) {
     if (frame.codedWidth === 0 || finalMaskTextures.length === 0) {
@@ -152,7 +156,7 @@ export const setupWebGL = (canvas: OffscreenCanvas | HTMLCanvasElement) => {
         bgBlurFrameBuffers,
         bgBlurTextures,
       );
-    } else {
+    } else if (customBackgroundImage) {
       gl.activeTexture(gl.TEXTURE0);
       gl.bindTexture(gl.TEXTURE_2D, bgTexture);
       gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, customBackgroundImage);
@@ -173,6 +177,7 @@ export const setupWebGL = (canvas: OffscreenCanvas | HTMLCanvasElement) => {
     gl.activeTexture(gl.TEXTURE0);
     gl.bindTexture(gl.TEXTURE_2D, backgroundTexture);
     gl.uniform1i(bgTextureLocation, 0);
+    gl.uniform1i(disableBackgroundLocation, backgroundImageDisabled ? 1 : 0);
 
     // Set frame texture
     gl.activeTexture(gl.TEXTURE1);
@@ -192,9 +197,10 @@ export const setupWebGL = (canvas: OffscreenCanvas | HTMLCanvasElement) => {
    */
   async function setBackgroundImage(image: ImageBitmap | null) {
     // Clear existing background
-    customBackgroundImage = getEmptyImageData();
+    customBackgroundImage = null;
 
     if (image) {
+      customBackgroundImage = getEmptyImageData();
       try {
         // Resize and crop the image to cover the canvas
         const croppedImage = await resizeImageToCover(image, canvas.width, canvas.height);
@@ -207,16 +213,20 @@ export const setupWebGL = (canvas: OffscreenCanvas | HTMLCanvasElement) => {
           error,
         );
       }
-    }
 
-    gl.activeTexture(gl.TEXTURE0);
-    gl.bindTexture(gl.TEXTURE_2D, bgTexture);
-    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, customBackgroundImage);
+      gl.activeTexture(gl.TEXTURE0);
+      gl.bindTexture(gl.TEXTURE_2D, bgTexture);
+      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, customBackgroundImage);
+    }
   }
 
   function setBlurRadius(radius: number | null) {
     blurRadius = radius ? Math.max(1, Math.floor(radius / downsampleFactor)) : null; // we are downsampling the blur texture, so decrease the radius here for better performance with a similar visual result
     setBackgroundImage(null);
+  }
+
+  function setBackgroundDisabled(disabled: boolean) {
+    backgroundImageDisabled = disabled;
   }
 
   function updateMask(mask: WebGLTexture) {
@@ -285,12 +295,12 @@ export const setupWebGL = (canvas: OffscreenCanvas | HTMLCanvasElement) => {
       if (customBackgroundImage instanceof ImageBitmap) {
         customBackgroundImage.close();
       }
-      customBackgroundImage = getEmptyImageData();
+      customBackgroundImage = null;
     }
     bgBlurTextures = [];
     bgBlurFrameBuffers = [];
     finalMaskTextures = [];
   }
 
-  return { renderFrame, updateMask, setBackgroundImage, setBlurRadius, cleanup };
+  return { renderFrame, updateMask, setBackgroundImage, setBlurRadius, setBackgroundDisabled, cleanup };
 };

--- a/src/webgl/shader-programs/compositeShader.ts
+++ b/src/webgl/shader-programs/compositeShader.ts
@@ -12,23 +12,23 @@ export const compositeFragmentShader = glsl`#version 300 es
   out vec4 fragColor;
   
   void main() {
-      
     vec4 frameTex = texture(frame, texCoords);
-    vec4 bgTex = texture(background, texCoords);
-
-    float maskVal = texture(mask, texCoords).r;
-
-    // Compute screen-space gradient to detect edge sharpness
-    float grad = length(vec2(dFdx(maskVal), dFdy(maskVal)));
-
-    float edgeSoftness = 2.0; // higher = softer
-    
-    // Create a smooth edge around binary transition
-    float smoothAlpha = smoothstep(0.5 - grad * edgeSoftness, 0.5 + grad * edgeSoftness, maskVal);
 
     if (disableBackground) {
       fragColor = frameTex;
     } else {
+      vec4 bgTex = texture(background, texCoords);
+
+      float maskVal = texture(mask, texCoords).r;
+
+      // Compute screen-space gradient to detect edge sharpness
+      float grad = length(vec2(dFdx(maskVal), dFdy(maskVal)));
+
+      float edgeSoftness = 2.0; // higher = softer
+
+      // Create a smooth edge around binary transition
+      float smoothAlpha = smoothstep(0.5 - grad * edgeSoftness, 0.5 + grad * edgeSoftness, maskVal);
+
       // Optional: preserve frame alpha, or override as fully opaque
       vec4 blended = mix(bgTex, vec4(frameTex.rgb, 1.0), 1.0 - smoothAlpha);
       fragColor = blended;

--- a/src/webgl/shader-programs/compositeShader.ts
+++ b/src/webgl/shader-programs/compositeShader.ts
@@ -6,6 +6,7 @@ export const compositeFragmentShader = glsl`#version 300 es
   precision mediump float;
   in vec2 texCoords;
   uniform sampler2D background;
+  uniform bool disableBackground;
   uniform sampler2D frame;
   uniform sampler2D mask;
   out vec4 fragColor;
@@ -25,10 +26,13 @@ export const compositeFragmentShader = glsl`#version 300 es
     // Create a smooth edge around binary transition
     float smoothAlpha = smoothstep(0.5 - grad * edgeSoftness, 0.5 + grad * edgeSoftness, maskVal);
 
-    // Optional: preserve frame alpha, or override as fully opaque
-    vec4 blended = mix(bgTex, vec4(frameTex.rgb, 1.0), 1.0 - smoothAlpha);
-    
-    fragColor = blended;
+    if (disableBackground) {
+      fragColor = frameTex;
+    } else {
+      // Optional: preserve frame alpha, or override as fully opaque
+      vec4 blended = mix(bgTex, vec4(frameTex.rgb, 1.0), 1.0 - smoothAlpha);
+      fragColor = blended;
+    }
   
   }
 `;
@@ -51,6 +55,7 @@ export function createCompositeProgram(gl: WebGL2RenderingContext) {
     mask: gl.getUniformLocation(compositeProgram, 'mask')!,
     frame: gl.getUniformLocation(compositeProgram, 'frame')!,
     background: gl.getUniformLocation(compositeProgram, 'background')!,
+    disableBackground: gl.getUniformLocation(compositeProgram, 'disableBackground')!,
     stepWidth: gl.getUniformLocation(compositeProgram, 'u_stepWidth')!,
   };
 


### PR DESCRIPTION
In a [past pull request](https://github.com/livekit/track-processors-js/pull/95), I had attempted to come up with a more elegant way to dynamically switch between track processor modes, but got the feedback what I was proposing was a bit too large of a leap and not backwards compatible enough.

### Summary

So, I've attempted to do this again in this change, only via a bit of different mechanism:
1. I've updated `BackgroundProcessor` to now optionally take a `mode` key when being initially set up to define an initial starting mode. For example: `BackgroundProcessor({ mode: 'background-blur', blurRadius: BLUR_RADIUS })` or `BackgroundProcessor({ mode: 'virtual-background', imagePath: "..." })`.
2. I've also updated `BackgroundProcessor`'s return value - it now returns a new superclass of `ProcessorWrapper` called `BackgroundProcessorWrapper` which exposes `switchToBackgroundBlur` and `switchToVirtualBackground` functions, which allows for more convenient switching as opposed to calling `updateTransformerOptions` manually.

In addition, per some [other](https://github.com/livekit/track-processors-js/issues/105) [discussions](https://github.com/livekit/track-processors-js/issues/85) I've had in other issues / pull requests, I wanted to put a demo together that would showcase an experience which wouldn't have any flicker due to media pipeline delay (technical info about this can be found [here](https://github.com/livekit/track-processors-js/pull/96)). In order to accomplish this, I've added a "disabled" mode to the `BackgroundProcessor` - so there now is a new `BackgroundProcessor({ mode: 'disabled' })` constructor signature, and also a new `switchToDisabled` method on the `BackgroundProcessorWrapper`.

This means that a user can effectively get rid of all "flicker" by enable the background processor immediately after connecting in the `disabled` mode, and then later on since the media pipeline is all set up, there will be no artifacts when enabling either effect.

### Demo
I also updated the demo - previously, the "toggle buttons" provided for a quite weird interface for both controlling whether the processor was enabled / disabled, and also setting which mode it is in. Now, these are controlled seperately.


https://github.com/user-attachments/assets/b9fe812c-dab8-4367-81e9-151ed9a30ca8