### PR TITLE
Add log output through copy of client sdk logging infrastructure

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,11 +26,12 @@
     "src"
   ],
   "dependencies": {
-    "@mediapipe/tasks-vision": "0.10.14"
+    "@mediapipe/tasks-vision": "0.10.14",
+    "loglevel": "^1.9.2"
   },
   "peerDependencies": {
-    "livekit-client": "^1.12.0 || ^2.1.0",
-    "@types/dom-mediacapture-transform": "^0.1.9"
+    "@types/dom-mediacapture-transform": "^0.1.9",
+    "livekit-client": "^1.12.0 || ^2.1.0"
   },
   "devDependencies": {
     "@changesets/cli": "^2.26.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       livekit-client:
         specifier: ^1.12.0 || ^2.1.0
         version: 2.15.2(@types/dom-mediacapture-record@1.0.22)
+      loglevel:
+        specifier: ^1.9.2
+        version: 1.9.2
     devDependencies:
       '@changesets/cli':
         specifier: ^2.26.2

--- a/src/ProcessorWrapper.ts
+++ b/src/ProcessorWrapper.ts
@@ -1,7 +1,7 @@
-import type { ProcessorOptions, Track, TrackProcessor } from 'livekit-client';
+import { type ProcessorOptions, type Track, type TrackProcessor } from 'livekit-client';
 import { TrackTransformer } from './transformers';
 import { createCanvas, waitForTrackResolution } from './utils';
-import log from './logger';
+import { LoggerNames, getLogger } from './logger';
 
 export interface ProcessorWrapperOptions {
   /**
@@ -79,6 +79,8 @@ export default class ProcessorWrapper<TransformerOptions extends Record<string, 
   private maxFps: number;
 
   private symbol?: Symbol;
+
+  private log = getLogger(LoggerNames.ProcessorWrapper);
 
   constructor(
     transformer: TrackTransformer<TransformerOptions>,
@@ -179,9 +181,9 @@ export default class ProcessorWrapper<TransformerOptions extends Record<string, 
       // destroy processor if stream errors - unless it's an abort error
       .catch((e) => {
         if (e instanceof DOMException && e.name === 'AbortError') {
-          log.log('stream processor path aborted');
+          this.log.log('stream processor path aborted');
         } else {
-          log.error('error when trying to pipe', e);
+          this.log.error('error when trying to pipe', e);
           this.destroy(symbol);
         }
       });
@@ -225,7 +227,7 @@ export default class ProcessorWrapper<TransformerOptions extends Record<string, 
         // @ts-ignore - The controller expects both VideoFrame & AudioData but we're only using VideoFrame
         this.transformer.transform(frame, controller);
       } catch (e) {
-        log.error('Error in transform:', e);
+        this.log.error('Error in transform:', e);
         frame.close();
       }
     };
@@ -262,7 +264,7 @@ export default class ProcessorWrapper<TransformerOptions extends Record<string, 
       }
 
       if (this.sourceDummy.paused) {
-        log.warn('Video is paused, trying to play');
+        this.log.warn('Video is paused, trying to play');
         this.sourceDummy.play();
         return;
       }
@@ -299,7 +301,7 @@ export default class ProcessorWrapper<TransformerOptions extends Record<string, 
               window.location.hostname === '127.0.0.1';
 
             if (isDevelopment && now - lastFpsLog > 5000) {
-              log.debug(
+              this.log.debug(
                 `[${this.name}] Estimated video FPS: ${estimatedVideoFps.toFixed(
                   1,
                 )}, Processing at: ${(frameCount / 5).toFixed(1)} FPS`,
@@ -334,7 +336,7 @@ export default class ProcessorWrapper<TransformerOptions extends Record<string, 
             }
           }
         } catch (e) {
-          log.error('Error in render loop:', e);
+          this.log.error('Error in render loop:', e);
         }
       }
       this.animationFrameId = requestAnimationFrame(renderLoop);

--- a/src/ProcessorWrapper.ts
+++ b/src/ProcessorWrapper.ts
@@ -1,6 +1,7 @@
 import type { ProcessorOptions, Track, TrackProcessor } from 'livekit-client';
 import { TrackTransformer } from './transformers';
 import { createCanvas, waitForTrackResolution } from './utils';
+import log from './logger';
 
 export interface ProcessorWrapperOptions {
   /**
@@ -178,9 +179,9 @@ export default class ProcessorWrapper<TransformerOptions extends Record<string, 
       // destroy processor if stream errors - unless it's an abort error
       .catch((e) => {
         if (e instanceof DOMException && e.name === 'AbortError') {
-          console.log('stream processor path aborted');
+          log.log('stream processor path aborted');
         } else {
-          console.error('error when trying to pipe', e);
+          log.error('error when trying to pipe', e);
           this.destroy(symbol);
         }
       });
@@ -224,7 +225,7 @@ export default class ProcessorWrapper<TransformerOptions extends Record<string, 
         // @ts-ignore - The controller expects both VideoFrame & AudioData but we're only using VideoFrame
         this.transformer.transform(frame, controller);
       } catch (e) {
-        console.error('Error in transform:', e);
+        log.error('Error in transform:', e);
         frame.close();
       }
     };
@@ -261,7 +262,7 @@ export default class ProcessorWrapper<TransformerOptions extends Record<string, 
       }
 
       if (this.sourceDummy.paused) {
-        console.warn('Video is paused, trying to play');
+        log.warn('Video is paused, trying to play');
         this.sourceDummy.play();
         return;
       }
@@ -298,7 +299,7 @@ export default class ProcessorWrapper<TransformerOptions extends Record<string, 
               window.location.hostname === '127.0.0.1';
 
             if (isDevelopment && now - lastFpsLog > 5000) {
-              console.debug(
+              log.debug(
                 `[${this.name}] Estimated video FPS: ${estimatedVideoFps.toFixed(
                   1,
                 )}, Processing at: ${(frameCount / 5).toFixed(1)} FPS`,
@@ -333,7 +334,7 @@ export default class ProcessorWrapper<TransformerOptions extends Record<string, 
             }
           }
         } catch (e) {
-          console.error('Error in render loop:', e);
+          log.error('Error in render loop:', e);
         }
       }
       this.animationFrameId = requestAnimationFrame(renderLoop);

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ export {
   type ProcessorWrapperOptions,
 };
 
+export * from './logger';
+
 /**
  * Determines if the current browser supports background processors
  */

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -10,8 +10,12 @@ export enum LogLevel {
 }
 
 export enum LoggerNames {
+  ProcessorWrapper = 'livekit-processor-wrapper',
   BackgroundProcessor = 'livekit-background-processor',
+  WebGl = 'livekit-track-processor-web-gl',
 }
+
+type LogLevelString = keyof typeof LogLevel;
 
 export type StructuredLogger = log.Logger & {
   trace: (msg: string, context?: object) => void;
@@ -25,7 +29,57 @@ export type StructuredLogger = log.Logger & {
 };
 
 let livekitLogger = log.getLogger('livekit');
+const livekitLoggers = Object.values(LoggerNames).map((name) => log.getLogger(name));
 
 livekitLogger.setDefaultLevel(LogLevel.info);
 
 export default livekitLogger as StructuredLogger;
+
+/**
+ * @internal
+ */
+export function getLogger(name: string) {
+  const logger = log.getLogger(name);
+  logger.setDefaultLevel(livekitLogger.getLevel());
+  return logger as StructuredLogger;
+}
+
+export function setLogLevel(level: LogLevel | LogLevelString, loggerName?: LoggerNames) {
+  if (loggerName) {
+    log.getLogger(loggerName).setLevel(level);
+  } else {
+    for (const logger of livekitLoggers) {
+      logger.setLevel(level);
+    }
+  }
+}
+
+export type LogExtension = (level: LogLevel, msg: string, context?: object) => void;
+
+/**
+ * use this to hook into the logging function to allow sending internal livekit logs to third party services
+ * if set, the browser logs will lose their stacktrace information (see https://github.com/pimterry/loglevel#writing-plugins)
+ */
+export function setLogExtension(extension: LogExtension, logger?: StructuredLogger) {
+  const loggers = logger ? [logger] : livekitLoggers;
+
+  loggers.forEach((logR) => {
+    const originalFactory = logR.methodFactory;
+
+    logR.methodFactory = (methodName, configLevel, loggerName) => {
+      const rawMethod = originalFactory(methodName, configLevel, loggerName);
+
+      const logLevel = LogLevel[methodName as LogLevelString];
+      const needLog = logLevel >= configLevel && logLevel < LogLevel.silent;
+
+      return (msg, context?: [msg: string, context: object]) => {
+        if (context) rawMethod(msg, context);
+        else rawMethod(msg);
+        if (needLog) {
+          extension(logLevel, msg, context);
+        }
+      };
+    };
+    logR.setLevel(logR.getLevel());
+  });
+}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,31 @@
+import * as log from 'loglevel';
+
+export enum LogLevel {
+  trace = 0,
+  debug = 1,
+  info = 2,
+  warn = 3,
+  error = 4,
+  silent = 5,
+}
+
+export enum LoggerNames {
+  BackgroundProcessor = 'livekit-background-processor',
+}
+
+export type StructuredLogger = log.Logger & {
+  trace: (msg: string, context?: object) => void;
+  debug: (msg: string, context?: object) => void;
+  info: (msg: string, context?: object) => void;
+  warn: (msg: string, context?: object) => void;
+  error: (msg: string, context?: object) => void;
+  setDefaultLevel: (level: log.LogLevelDesc) => void;
+  setLevel: (level: log.LogLevelDesc) => void;
+  getLevel: () => number;
+};
+
+let livekitLogger = log.getLogger('livekit');
+
+livekitLogger.setDefaultLevel(LogLevel.info);
+
+export default livekitLogger as StructuredLogger;

--- a/src/transformers/BackgroundTransformer.ts
+++ b/src/transformers/BackgroundTransformer.ts
@@ -1,4 +1,5 @@
 import * as vision from '@mediapipe/tasks-vision';
+import log from '../logger';
 import { dependencies } from '../../package.json';
 import VideoTransformer from './VideoTransformer';
 import { VideoTransformerInitOptions } from './types';
@@ -77,7 +78,7 @@ export default class BackgroundProcessor extends VideoTransformer<BackgroundOpti
     // Skip loading the image here if update already loaded the image below
     if (this.options?.imagePath) {
       await this.loadAndSetBackground(this.options.imagePath).catch((err) =>
-        console.error('Error while loading processor background image: ', err),
+        log.error('Error while loading processor background image: ', err),
       );
     }
     if (this.options.blurRadius) {
@@ -112,7 +113,7 @@ export default class BackgroundProcessor extends VideoTransformer<BackgroundOpti
     let enqueuedFrame = false;
     try {
       if (!(frame instanceof VideoFrame) || frame.codedWidth === 0 || frame.codedHeight === 0) {
-        console.debug('empty frame detected, ignoring');
+        log.debug('empty frame detected, ignoring');
         return;
       }
 
@@ -195,7 +196,7 @@ export default class BackgroundProcessor extends VideoTransformer<BackgroundOpti
       }
       await segmentationPromise;
     } catch (e) {
-      console.error('Error while processing frame: ', e);
+      log.error('Error while processing frame: ', e);
     } finally {
       if (!enqueuedFrame) {
         frame.close();

--- a/src/transformers/BackgroundTransformer.ts
+++ b/src/transformers/BackgroundTransformer.ts
@@ -1,5 +1,5 @@
 import * as vision from '@mediapipe/tasks-vision';
-import log from '../logger';
+import { getLogger, LoggerNames } from '../logger';
 import { dependencies } from '../../package.json';
 import VideoTransformer from './VideoTransformer';
 import { VideoTransformerInitOptions } from './types';
@@ -45,6 +45,8 @@ export default class BackgroundProcessor extends VideoTransformer<BackgroundOpti
 
   isFirstFrame = true;
 
+  private log = getLogger(LoggerNames.ProcessorWrapper);
+
   constructor(opts: BackgroundOptions) {
     super();
     this.options = opts;
@@ -78,7 +80,7 @@ export default class BackgroundProcessor extends VideoTransformer<BackgroundOpti
     // Skip loading the image here if update already loaded the image below
     if (this.options?.imagePath) {
       await this.loadAndSetBackground(this.options.imagePath).catch((err) =>
-        log.error('Error while loading processor background image: ', err),
+        this.log.error('Error while loading processor background image: ', err),
       );
     }
     if (this.options.blurRadius) {
@@ -113,7 +115,7 @@ export default class BackgroundProcessor extends VideoTransformer<BackgroundOpti
     let enqueuedFrame = false;
     try {
       if (!(frame instanceof VideoFrame) || frame.codedWidth === 0 || frame.codedHeight === 0) {
-        log.debug('empty frame detected, ignoring');
+        this.log.debug('empty frame detected, ignoring');
         return;
       }
 
@@ -196,7 +198,7 @@ export default class BackgroundProcessor extends VideoTransformer<BackgroundOpti
       }
       await segmentationPromise;
     } catch (e) {
-      log.error('Error while processing frame: ', e);
+      this.log.error('Error while processing frame: ', e);
     } finally {
       if (!enqueuedFrame) {
         frame.close();

--- a/src/webgl/index.ts
+++ b/src/webgl/index.ts
@@ -4,7 +4,7 @@
  * - downsample the video texture in background blur scenario before applying the (gaussian) blur for better performance
  *
  */
-import log from '../logger';
+import { getLogger, LoggerNames} from '../logger';
 import { applyBlur, createBlurProgram } from './shader-programs/blurShader';
 import { createBoxBlurProgram } from './shader-programs/boxBlurShader';
 import { createCompositeProgram } from './shader-programs/compositeShader';
@@ -16,6 +16,8 @@ import {
   initTexture,
   resizeImageToCover,
 } from './utils';
+
+const log = getLogger(LoggerNames.WebGl);
 
 export const setupWebGL = (canvas: OffscreenCanvas | HTMLCanvasElement) => {
   const gl = canvas.getContext('webgl2', {

--- a/src/webgl/index.ts
+++ b/src/webgl/index.ts
@@ -4,6 +4,7 @@
  * - downsample the video texture in background blur scenario before applying the (gaussian) blur for better performance
  *
  */
+import log from '../logger';
 import { applyBlur, createBlurProgram } from './shader-programs/blurShader';
 import { createBoxBlurProgram } from './shader-programs/boxBlurShader';
 import { createCompositeProgram } from './shader-programs/compositeShader';
@@ -27,7 +28,7 @@ export const setupWebGL = (canvas: OffscreenCanvas | HTMLCanvasElement) => {
   const downsampleFactor = 4;
 
   if (!gl) {
-    console.error('Failed to create WebGL context');
+    log.error('Failed to create WebGL context');
     return undefined;
   }
 
@@ -199,7 +200,7 @@ export const setupWebGL = (canvas: OffscreenCanvas | HTMLCanvasElement) => {
         // Store the cropped and resized image
         customBackgroundImage = croppedImage;
       } catch (error) {
-        console.error(
+        log.error(
           'Error processing background image, falling back to black background:',
           error,
         );

--- a/src/webgl/utils.ts
+++ b/src/webgl/utils.ts
@@ -1,4 +1,6 @@
-import log from '../logger';
+import { getLogger, LoggerNames} from '../logger';
+
+const log = getLogger(LoggerNames.WebGl);
 
 /**
  * Initialize a WebGL texture

--- a/src/webgl/utils.ts
+++ b/src/webgl/utils.ts
@@ -1,3 +1,5 @@
+import log from '../logger';
+
 /**
  * Initialize a WebGL texture
  */
@@ -24,7 +26,7 @@ export function createShader(
   gl.shaderSource(shader, source);
   gl.compileShader(shader);
   if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
-    console.error('Shader compile failed:', gl.getShaderInfoLog(shader));
+    log.error('Shader compile failed:', gl.getShaderInfoLog(shader));
     gl.deleteShader(shader);
     throw new Error('Shader compile failed');
   }
@@ -41,7 +43,7 @@ export function createProgram(
   gl.attachShader(program, fs);
   gl.linkProgram(program);
   if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
-    console.error('Program link failed:', gl.getProgramInfoLog(program));
+    log.error('Program link failed:', gl.getProgramInfoLog(program));
     throw new Error('Program link failed');
   }
   return program;


### PR DESCRIPTION
Adds a copy of [src/logger.ts](https://github.com/livekit/client-sdk-js/blob/main/src/logger.ts) from the client sdk to this package, and wires up all logs to go through this logger implementation rather than via `console`.

One important caveat: logs from the mediapipe webworker aren't going through this logging infrastructure right now. Poking around in a debugger, it does look like there's a way to swap out `console.log` at the emscripten level but mediapipe abstracts over that interface in a way where it doesn't really look like there's any way to inject some custom logging implementation without fully forking mediapipe, which IMO probably isn't worth it for this.