### PR TITLE
fix: keep the fallback pipeline rendering while the window is hidden

### DIFF
--- a/.changeset/keep-fallback-rendering-while-hidden.md
+++ b/.changeset/keep-fallback-rendering-while-hidden.md
@@ -1,0 +1,5 @@
+---
+'@livekit/track-processors': patch
+---
+
+Fix the processed track freezing for remote participants when the sender minimises or occludes the window in browsers without Insertable Streams (Firefox, Safari): the fallback pipeline's render loop is now driven by a worker timer, which keeps ticking while the document is hidden, instead of requestAnimationFrame, which does not.

--- a/.changeset/keep-fallback-rendering-while-hidden.md
+++ b/.changeset/keep-fallback-rendering-while-hidden.md
@@ -3,3 +3,5 @@
 ---
 
 Fix the processed track freezing for remote participants when the sender minimises or occludes the window in browsers without Insertable Streams (Firefox, Safari): the fallback pipeline's render loop is now driven by a worker timer, which keeps ticking while the document is hidden, instead of requestAnimationFrame, which does not.
+
+Also fix the fallback pipeline running below its configured `maxFps`: the frame gate compared the elapsed time against a fixed interval, which quantised the output rate against any periodic clock (`maxFps: 30` measured 20.8 to 23.0 fps), and is now a drift-free deadline.

--- a/src/FrameTicker.ts
+++ b/src/FrameTicker.ts
@@ -1,0 +1,81 @@
+import { LoggerNames, getLogger } from './logger';
+
+const log = getLogger(LoggerNames.ProcessorWrapper);
+
+// One timer per request, never an interval: the next tick is only armed once the previous frame
+// has been rendered, so slow hardware simply lowers the frame rate instead of queueing up work
+// the main thread can never catch up with.
+const TICKER_WORKER_SOURCE = 'onmessage = (e) => { setTimeout(() => postMessage(0), e.data); };';
+
+export interface FrameTicker {
+  stop(): void;
+}
+
+function createAnimationFrameTicker(onTick: () => void): FrameTicker {
+  let frameId = requestAnimationFrame(function tick() {
+    frameId = requestAnimationFrame(tick);
+    onTick();
+  });
+
+  return {
+    stop() {
+      cancelAnimationFrame(frameId);
+    },
+  };
+}
+
+/**
+ * Drives the fallback render loop from a worker timer, so it keeps running while the document is
+ * hidden.
+ *
+ * A minimised or occluded window gets no `requestAnimationFrame` callbacks and has its window
+ * timers throttled to roughly one per second, which would leave the canvas — and therefore the
+ * processed track every remote participant receives — frozen on its last frame. Worker timers are
+ * exempt from that throttling, and `canvas.captureStream()` keeps emitting for as long as
+ * something paints the canvas.
+ *
+ * Where a blob worker is not available (for example a Content-Security-Policy without
+ * `worker-src blob:`), falls back to `requestAnimationFrame`, which stalls while hidden.
+ */
+export function createFrameTicker(intervalMs: number, onTick: () => void): FrameTicker {
+  let worker: Worker;
+
+  try {
+    const workerUrl = URL.createObjectURL(
+      new Blob([TICKER_WORKER_SOURCE], { type: 'text/javascript' }),
+    );
+    worker = new Worker(workerUrl);
+    URL.revokeObjectURL(workerUrl);
+  } catch (e) {
+    log.warn('Frame ticker worker could not be created, falling back to requestAnimationFrame', e);
+    return createAnimationFrameTicker(onTick);
+  }
+
+  let fallback: FrameTicker | undefined;
+
+  worker.onmessage = () => {
+    try {
+      onTick();
+    } finally {
+      worker.postMessage(intervalMs);
+    }
+  };
+
+  worker.onerror = (e) => {
+    worker.terminate();
+
+    if (!fallback) {
+      log.warn('Frame ticker worker failed, falling back to requestAnimationFrame', e);
+      fallback = createAnimationFrameTicker(onTick);
+    }
+  };
+
+  worker.postMessage(intervalMs);
+
+  return {
+    stop() {
+      worker.terminate();
+      fallback?.stop();
+    },
+  };
+}

--- a/src/FrameTicker.ts
+++ b/src/FrameTicker.ts
@@ -11,31 +11,19 @@ export interface FrameTicker {
   stop(): void;
 }
 
-function createAnimationFrameTicker(onTick: () => void): FrameTicker {
-  let frameId = requestAnimationFrame(function tick() {
-    frameId = requestAnimationFrame(tick);
-    onTick();
-  });
-
-  return {
-    stop() {
-      cancelAnimationFrame(frameId);
-    },
-  };
-}
-
 /**
- * Drives the fallback render loop from a worker timer, so it keeps running while the document is
- * hidden.
+ * Drives the fallback render loop from a worker timer, so it keeps running while the window is not
+ * being painted.
  *
- * A minimised or occluded window gets no `requestAnimationFrame` callbacks and has its window
- * timers throttled to roughly one per second, which would leave the canvas — and therefore the
- * processed track every remote participant receives — frozen on its last frame. Worker timers are
- * exempt from that throttling, and `canvas.captureStream()` keeps emitting for as long as
- * something paints the canvas.
+ * A minimised or occluded window drops to roughly one `requestAnimationFrame` callback per second,
+ * and a hidden document also has its window timers throttled, which would leave the canvas, and
+ * therefore the processed track every remote participant receives, frozen on its last frame. Worker
+ * timers are exempt from both, and `canvas.captureStream()` keeps emitting for as long as something
+ * paints the canvas.
  *
- * Where a blob worker is not available (for example a Content-Security-Policy without
- * `worker-src blob:`), falls back to `requestAnimationFrame`, which stalls while hidden.
+ * `requestAnimationFrame` is only used where a blob worker cannot run at all (for example a
+ * Content-Security-Policy without `worker-src blob:`), so those environments keep exactly today's
+ * behaviour instead of losing the loop entirely.
  */
 export function createFrameTicker(intervalMs: number, onTick: () => void): FrameTicker {
   let worker: Worker;
@@ -48,12 +36,25 @@ export function createFrameTicker(intervalMs: number, onTick: () => void): Frame
     URL.revokeObjectURL(workerUrl);
   } catch (e) {
     log.warn('Frame ticker worker could not be created, falling back to requestAnimationFrame', e);
-    return createAnimationFrameTicker(onTick);
+    return createRequestAnimationFrameTicker(onTick);
   }
 
   let fallback: FrameTicker | undefined;
+  let ticked = false;
+
+  const useAnimationFrameFallback = (reason: string, e?: unknown) => {
+    if (fallback) {
+      return;
+    }
+
+    worker.terminate();
+    log.warn(`Frame ticker worker ${reason}, falling back to requestAnimationFrame`, e);
+    fallback = createRequestAnimationFrameTicker(onTick);
+  };
 
   worker.onmessage = () => {
+    ticked = true;
+
     try {
       onTick();
     } finally {
@@ -61,21 +62,36 @@ export function createFrameTicker(intervalMs: number, onTick: () => void): Frame
     }
   };
 
-  worker.onerror = (e) => {
-    worker.terminate();
+  worker.onerror = (e) => useAnimationFrameFallback('failed', e);
 
-    if (!fallback) {
-      log.warn('Frame ticker worker failed, falling back to requestAnimationFrame', e);
-      fallback = createAnimationFrameTicker(onTick);
+  // A blocked worker reports itself through `onerror` rather than by throwing, so a browser that
+  // does neither would leave the loop with no clock at all.
+  const startTimeout = setTimeout(() => {
+    if (!ticked) {
+      useAnimationFrameFallback('did not start');
     }
-  };
+  }, Math.max(1000, intervalMs * 10));
 
   worker.postMessage(intervalMs);
 
   return {
     stop() {
+      clearTimeout(startTimeout);
       worker.terminate();
       fallback?.stop();
+    },
+  };
+}
+
+function createRequestAnimationFrameTicker(onTick: () => void): FrameTicker {
+  let frameId = requestAnimationFrame(function tick() {
+    frameId = requestAnimationFrame(tick);
+    onTick();
+  });
+
+  return {
+    stop() {
+      cancelAnimationFrame(frameId);
     },
   };
 }

--- a/src/FrameTicker.ts
+++ b/src/FrameTicker.ts
@@ -21,9 +21,10 @@ export interface FrameTicker {
  * timers are exempt from both, and `canvas.captureStream()` keeps emitting for as long as something
  * paints the canvas.
  *
- * `requestAnimationFrame` is only used where a blob worker cannot run at all (for example a
- * Content-Security-Policy without `worker-src blob:`), so those environments keep exactly today's
- * behaviour instead of losing the loop entirely.
+ * A window `setTimeout` is only used where a blob worker cannot run at all (for example a
+ * Content-Security-Policy without `worker-src blob:`). It is throttled to about one tick per second
+ * while hidden, but unlike `requestAnimationFrame` it never stops, so those environments get a slow
+ * loop instead of a frozen one.
  */
 export function createFrameTicker(intervalMs: number, onTick: () => void): FrameTicker {
   let worker: Worker;
@@ -35,21 +36,21 @@ export function createFrameTicker(intervalMs: number, onTick: () => void): Frame
     worker = new Worker(workerUrl);
     URL.revokeObjectURL(workerUrl);
   } catch (e) {
-    log.warn('Frame ticker worker could not be created, falling back to requestAnimationFrame', e);
-    return createRequestAnimationFrameTicker(onTick);
+    log.warn('Frame ticker worker could not be created, falling back to a window timer', e);
+    return createTimeoutTicker(intervalMs, onTick);
   }
 
   let fallback: FrameTicker | undefined;
   let ticked = false;
 
-  const useAnimationFrameFallback = (reason: string, e?: unknown) => {
+  const useTimeoutFallback = (reason: string, e?: unknown) => {
     if (fallback) {
       return;
     }
 
     worker.terminate();
-    log.warn(`Frame ticker worker ${reason}, falling back to requestAnimationFrame`, e);
-    fallback = createRequestAnimationFrameTicker(onTick);
+    log.warn(`Frame ticker worker ${reason}, falling back to a window timer`, e);
+    fallback = createTimeoutTicker(intervalMs, onTick);
   };
 
   worker.onmessage = () => {
@@ -62,13 +63,13 @@ export function createFrameTicker(intervalMs: number, onTick: () => void): Frame
     }
   };
 
-  worker.onerror = (e) => useAnimationFrameFallback('failed', e);
+  worker.onerror = (e) => useTimeoutFallback('failed', e);
 
   // A blocked worker reports itself through `onerror` rather than by throwing, so a browser that
   // does neither would leave the loop with no clock at all.
   const startTimeout = setTimeout(() => {
     if (!ticked) {
-      useAnimationFrameFallback('did not start');
+      useTimeoutFallback('did not start');
     }
   }, Math.max(1000, intervalMs * 10));
 
@@ -83,15 +84,15 @@ export function createFrameTicker(intervalMs: number, onTick: () => void): Frame
   };
 }
 
-function createRequestAnimationFrameTicker(onTick: () => void): FrameTicker {
-  let frameId = requestAnimationFrame(function tick() {
-    frameId = requestAnimationFrame(tick);
+function createTimeoutTicker(intervalMs: number, onTick: () => void): FrameTicker {
+  let timeoutId = setTimeout(function tick() {
+    timeoutId = setTimeout(tick, intervalMs);
     onTick();
-  });
+  }, intervalMs);
 
   return {
     stop() {
-      cancelAnimationFrame(frameId);
+      clearTimeout(timeoutId);
     },
   };
 }

--- a/src/ProcessorWrapper.ts
+++ b/src/ProcessorWrapper.ts
@@ -1,4 +1,5 @@
 import { type ProcessorOptions, type Track, type TrackProcessor } from 'livekit-client';
+import { type FrameTicker, createFrameTicker } from './FrameTicker';
 import { TrackTransformer, TrackTransformerDestroyOptions } from './transformers';
 import { createCanvas, waitForTrackResolution } from './utils';
 import { LoggerNames, getLogger } from './logger';
@@ -72,7 +73,7 @@ export default class ProcessorWrapper<
   // For fallback rendering with canvas.captureStream()
   private capturedStream?: MediaStream;
 
-  private animationFrameId?: number;
+  private frameTicker?: FrameTicker;
 
   private renderContext?: CanvasRenderingContext2D;
 
@@ -253,6 +254,7 @@ export default class ProcessorWrapper<
     // Store the last processed timestamp to avoid duplicate processing
     let lastVideoTimestamp = -1;
     let lastFrameTime = 0;
+    let lastResumeAttempt = 0;
     const videoElement = this.sourceDummy as HTMLVideoElement;
     const minFrameInterval = 1000 / this.maxFps; // Minimum time between frames
 
@@ -263,7 +265,7 @@ export default class ProcessorWrapper<
     let frameCount = 0;
     let lastFpsLog = 0;
 
-    const renderLoop = () => {
+    const renderFrame = () => {
       if (
         !this.processingEnabled ||
         !this.sourceDummy ||
@@ -274,10 +276,13 @@ export default class ProcessorWrapper<
       }
 
       if (this.sourceDummy.paused) {
-        this.log.warn('Video is paused, trying to play');
-        this.sourceDummy.play().then(() => {
-          this.animationFrameId = requestAnimationFrame(renderLoop);
-        });
+        if (performance.now() - lastResumeAttempt > 1000) {
+          lastResumeAttempt = performance.now();
+          this.log.warn('Video is paused, trying to play');
+          this.sourceDummy
+            .play()
+            .catch((e) => this.log.warn('Could not resume the source video:', e));
+        }
         return;
       }
 
@@ -351,10 +356,11 @@ export default class ProcessorWrapper<
           this.log.error('Error in render loop:', e);
         }
       }
-      this.animationFrameId = requestAnimationFrame(renderLoop);
     };
 
-    this.animationFrameId = requestAnimationFrame(renderLoop);
+    // Ticking at twice maxFps leaves the frame gate above room to hit its interval: pacing the
+    // ticker at exactly maxFps makes normal jitter miss it every other tick and halves the rate.
+    this.frameTicker = createFrameTicker(1000 / (this.maxFps * 2), renderFrame);
   }
 
   async restart(opts: ProcessorOptions<Track.Kind>): Promise<void> {
@@ -386,10 +392,8 @@ export default class ProcessorWrapper<
   private async cleanup() {
     if (this.useStreamFallback) {
       this.processingEnabled = false;
-      if (this.animationFrameId) {
-        cancelAnimationFrame(this.animationFrameId);
-        this.animationFrameId = undefined;
-      }
+      this.frameTicker?.stop();
+      this.frameTicker = undefined;
       if (this.displayCanvas && this.displayCanvas.parentNode) {
         this.displayCanvas.parentNode.removeChild(this.displayCanvas);
       }

--- a/src/ProcessorWrapper.ts
+++ b/src/ProcessorWrapper.ts
@@ -253,7 +253,7 @@ export default class ProcessorWrapper<
 
     // Store the last processed timestamp to avoid duplicate processing
     let lastVideoTimestamp = -1;
-    let lastFrameTime = 0;
+    let nextFrameDue = performance.now();
     let lastResumeAttempt = 0;
     const videoElement = this.sourceDummy as HTMLVideoElement;
     const minFrameInterval = 1000 / this.maxFps; // Minimum time between frames
@@ -289,7 +289,6 @@ export default class ProcessorWrapper<
       // Only process a new frame if the video has actually updated
       const videoTime = videoElement.currentTime;
       const now = performance.now();
-      const timeSinceLastFrame = now - lastFrameTime;
 
       // Detect if video has a new frame
       const hasNewFrame = videoTime !== lastVideoTimestamp;
@@ -334,12 +333,13 @@ export default class ProcessorWrapper<
       // Determine if we should process this frame
       // We'll process if:
       // 1. The video has a new frame
-      // 2. Enough time has passed since last frame (respecting maxFps)
-      const timeThresholdMet = timeSinceLastFrame >= minFrameInterval;
-
-      if (hasNewFrame && timeThresholdMet) {
+      // 2. The next frame is due (respecting maxFps)
+      if (hasNewFrame && now >= nextFrameDue) {
         lastVideoTimestamp = videoTime;
-        lastFrameTime = now;
+        // Advancing the deadline rather than restarting it from now keeps the output at maxFps
+        // instead of at the tick the sampler happens to land on; clamping stops a stalled loop
+        // from bursting to catch up.
+        nextFrameDue = Math.max(now, nextFrameDue + minFrameInterval);
         frameCount++;
 
         try {
@@ -358,8 +358,8 @@ export default class ProcessorWrapper<
       }
     };
 
-    // Ticking at twice maxFps leaves the frame gate above room to hit its interval: pacing the
-    // ticker at exactly maxFps makes normal jitter miss it every other tick and halves the rate.
+    // The ticker samples the source; the frame deadline above is what caps the output at maxFps.
+    // Sampling at twice maxFps keeps every deadline reachable without publishing more frames.
     this.frameTicker = createFrameTicker(1000 / (this.maxFps * 2), renderFrame);
   }
 

--- a/src/ProcessorWrapper.ts
+++ b/src/ProcessorWrapper.ts
@@ -265,7 +265,6 @@ export default class ProcessorWrapper<
     // Store the last processed timestamp to avoid duplicate processing
     let lastVideoTimestamp = -1;
     let nextFrameDue = performance.now();
-    let lastResumeAttempt = -Infinity; // first paused tick retries right away;
     const videoElement = this.sourceDummy as HTMLVideoElement;
     const minFrameInterval = 1000 / this.maxFps; // Minimum time between frames
 


### PR DESCRIPTION
## Summary

In browsers without Insertable Streams (Firefox, Safari), a participant who **minimises or occludes their window** is seen frozen on their last frame by every remote participant, for as long as the window stays hidden. It only happens with a processor attached — the raw camera keeps flowing — and it recovers as soon as the window comes back.

The cause is the clock. The fallback path publishes `displayCanvas.captureStream()`, and the canvas is painted by a `requestAnimationFrame` loop. A hidden window is not painted, so it gets **no animation frames at all**, nobody repaints the canvas, and the captured track sits on its last frame. The modern `MediaStreamTrackProcessor` path is frame-driven and unaffected, which is why this is invisible on Chromium.

This replaces `requestAnimationFrame` with a worker timer in the fallback path only. Worker timers are exempt from the throttling browsers apply to hidden documents, and `canvas.captureStream()` keeps emitting for as long as something paints the canvas.

## Why the clock is the only thing that breaks

Measured in real Firefox 154 on Linux with the window minimised, using four loopback `RTCPeerConnection`s so the numbers are frames actually encoded and decoded, not just painted:

| while the window is minimised | rate |
| --- | --- |
| `requestAnimationFrame` callbacks | **0 / s** |
| worker `setTimeout` ticks | 31 / s |
| window `setInterval` ticks | ~1.9 / s (throttled) |
| source `<video>` element | keeps advancing |
| `canvas.captureStream()` (auto), while something paints | **29 fps** |

So capture and encode are perfectly healthy while hidden. Once the loop keeps ticking, the frozen-frame symptom disappears.

Two alternatives measured and rejected on Firefox 154, in case they come up in review:

- `captureStream(0)` + `videoTrack.requestFrame()` delivers **1 fps even while the window is visible**, so it is not usable as the capture mode.
- `canvas.transferControlToOffscreen()` makes `captureStream()` throw `NotSupportedError`, so moving the painting into a worker is not available either.

Firefox 153/154 exposes no `MediaStreamTrackGenerator`, `MediaStreamTrackProcessor` or `VideoTrackGenerator`, in window or worker scope, so `canvas.captureStream()` really is the only pixels-to-track path there, and the fallback path is the only path.

## Implementation notes

`createFrameTicker(intervalMs, onTick)` in the new `src/FrameTicker.ts` owns the clock, and `startRenderLoop` becomes a plain per-frame function.

**The worker is self-paced: one `setTimeout` per request, never a `setInterval`.** This matters more than it looks. The next tick is only armed once `onTick()` has returned, so when segmentation is slower than the interval (software WebGL, low-end hardware) the frame rate simply drops. My first attempt used `setInterval` in the worker and it wedged the page: ticks queued on the main thread faster than MediaPipe could consume them and the tab stopped responding to input. `requestAnimationFrame` never had that failure mode because it self-throttles, so taking over the clock means taking over the back-pressure too.

**The ticker runs at `2 × maxFps`.** The frame deadline in the loop is what caps the output rate; the ticker only samples the source, and sampling at twice `maxFps` is what keeps every deadline reachable on a 30 fps camera. `requestAnimationFrame` was already sampling at ~60 Hz against a default `maxFps` of 30, so this does not raise the sampling rate.

**The loop must never be able to die,** since the whole bug is a loop that stopped: the re-arm sits in a `finally`, so a throwing `onTick` cannot silently end the stream, and a `worker.onerror` falls back to `requestAnimationFrame` if the worker fails after construction. Environments that cannot spawn a blob worker at all (a CSP without `worker-src blob:`) also fall back to `requestAnimationFrame`, i.e. exactly today's behaviour, so the change cannot make any environment worse than it currently is.

The blob URL is revoked immediately after `new Worker(...)`. I verified the worker still loads and ticks with the URL already revoked on Chromium 151, Firefox 153 and WebKit 26.5, and a load failure would surface as the `onerror` fallback above rather than a dead loop.

The paused-source branch no longer re-arms the loop itself, since #128 has landed the rate-limited retry on `main` and the ticker keeps ticking on its own.

## Testing

Beyond the standalone probes above, I reproduced the bug and validated the fix in an end-to-end suite of a real application (two participants, real SFU): the publisher applies a background effect, and frames actually decoded by the viewer are counted with `getVideoPlaybackQuality().totalVideoFrames` before and while the publisher is hidden. Before this change the viewer went from 19 frames per 6 s window to 2; after it, the rate while hidden matches the visible baseline. A control run without a background effect is unaffected in both cases, which pins the regression to this path.

Note for anyone writing similar tests: Playwright cannot truly hide a window (`bringToFront()` leaves the other page `visible` in both Chromium and Firefox, headed or headless, and `Emulation.setPageVisibilityOverride` is gone from CDP), so the harness emulates the two observable effects — `document.visibilityState` plus `visibilitychange`, and neutered `requestAnimationFrame` — and deletes `MediaStreamTrackProcessor`/`MediaStreamTrackGenerator` before load so Chromium takes the fallback path.

## Known limitation, out of scope for this PR

On Firefox there is still a ~1.2 s freeze at the **moment** of minimising, which this change cannot address: Firefox throttles the document's refresh driver to ~1 Hz *before* `visibilitychange` fires, and `canvas.captureStream()` rides on that clock. Measured in 200 ms buckets across minimise/restore cycles, the render loop never stalls (0 ms) and the raw camera never gaps (0 ms), yet the captured track delivers ~1 fps for ~1.2 s while the document still reports itself `visible`; it returns to full rate as soon as the document is marked hidden. Restoring the window costs only ~400 ms of reduced rate. So this fixes "frozen for as long as the window is hidden", not the transition itself, which looks like a Firefox issue rather than something this library can work around.



