### PR TITLE
fix: keep mask buffers and canvas fallback output in sync with the frame size

### DIFF
--- a/.changeset/buffers-follow-frame-size.md
+++ b/.changeset/buffers-follow-frame-size.md
@@ -1,0 +1,5 @@
+---
+'@livekit/track-processors': patch
+---
+
+Fix the background mask coming out clipped and offset when the frame size differs from the track settings (device rotation, iPhone portrait), size the canvas fallback output to the source video's size, and keep the fallback render loop alive when `play()` is rejected.

--- a/src/ProcessorWrapper.ts
+++ b/src/ProcessorWrapper.ts
@@ -217,6 +217,17 @@ export default class ProcessorWrapper<
       const controller = {
         enqueue: (processedFrame: VideoFrame) => {
           if (this.renderContext && this.displayCanvas) {
+            // Follow the video element, not the frame: both track rotation, but on iOS frames keep the
+            // unrotated sensor size (640x480 for a 480x640 track) and the published track must match the track.
+            const { videoWidth, videoHeight } = this.sourceDummy as HTMLVideoElement;
+            if (
+              videoWidth &&
+              videoHeight &&
+              (this.displayCanvas.width !== videoWidth || this.displayCanvas.height !== videoHeight)
+            ) {
+              this.displayCanvas.width = videoWidth;
+              this.displayCanvas.height = videoHeight;
+            }
             // Draw the processed frame to the visible canvas
             this.renderContext.drawImage(
               processedFrame,
@@ -262,6 +273,7 @@ export default class ProcessorWrapper<
     let lastVideoTimeChange = 0;
     let frameCount = 0;
     let lastFpsLog = 0;
+    let lastPlayAttempt = -Infinity; // first paused tick retries right away
 
     const renderLoop = () => {
       if (
@@ -274,10 +286,15 @@ export default class ProcessorWrapper<
       }
 
       if (this.sourceDummy.paused) {
-        this.log.warn('Video is paused, trying to play');
-        this.sourceDummy.play().then(() => {
-          this.animationFrameId = requestAnimationFrame(renderLoop);
-        });
+        // play() can be refused (NotAllowedError on WebKit outside a user gesture); re-arming only from its
+        // .then() (#121) ended the loop for good on rejection. Re-arm every frame instead, like the
+        // no-new-frame path, and retry play() once a second.
+        if (performance.now() - lastPlayAttempt > 1000) {
+          lastPlayAttempt = performance.now();
+          this.log.warn('Video is paused, trying to play');
+          this.sourceDummy.play().catch((e) => this.log.warn('Unable to play video', e));
+        }
+        this.animationFrameId = requestAnimationFrame(renderLoop);
         return;
       }
 

--- a/src/webgl/index.ts
+++ b/src/webgl/index.ts
@@ -15,6 +15,7 @@ import {
   getEmptyImageData,
   initTexture,
   resizeImageToCover,
+  resizeTexture,
 } from './utils';
 
 const log = getLogger(LoggerNames.WebGl);
@@ -80,8 +81,8 @@ export const setupWebGL = (canvas: OffscreenCanvas | HTMLCanvasElement) => {
   bgBlurTextures.push(initTexture(gl, 3)); // For blur pass 1
   bgBlurTextures.push(initTexture(gl, 4)); // For blur pass 2
 
-  const bgBlurTextureWidth = Math.floor(canvas.width / downsampleFactor);
-  const bgBlurTextureHeight = Math.floor(canvas.height / downsampleFactor);
+  let bgBlurTextureWidth = Math.floor(canvas.width / downsampleFactor);
+  let bgBlurTextureHeight = Math.floor(canvas.height / downsampleFactor);
 
   const downSampler = createDownSampler(gl, bgBlurTextureWidth, bgBlurTextureHeight);
 
@@ -107,6 +108,36 @@ export const setupWebGL = (canvas: OffscreenCanvas | HTMLCanvasElement) => {
     createFramebuffer(gl, finalMaskTextures[1], canvas.width, canvas.height),
   ];
 
+  // Store custom background image, cropped to cover the canvas, and the source it was cropped from
+  let customBackgroundImage: ImageBitmap | ImageData | null = null;
+  let backgroundSourceImage: ImageBitmap | null = null;
+
+  // The transformer sets the canvas to each frame's display size, which drifts from the size the buffers
+  // were allocated at (device rotation, iOS reporting the unrotated sensor size). Called from updateMask
+  // and renderFrame: whichever first sees a new size reallocates, the other only compares.
+  let bufferWidth = canvas.width;
+  let bufferHeight = canvas.height;
+
+  function ensureBuffersMatchCanvas() {
+    if (canvas.width === bufferWidth && canvas.height === bufferHeight) {
+      return;
+    }
+    bufferWidth = canvas.width;
+    bufferHeight = canvas.height;
+    bgBlurTextureWidth = Math.floor(bufferWidth / downsampleFactor);
+    bgBlurTextureHeight = Math.floor(bufferHeight / downsampleFactor);
+    for (const texture of [downSampler.texture, ...bgBlurTextures]) {
+      resizeTexture(gl, texture, bgBlurTextureWidth, bgBlurTextureHeight);
+    }
+    for (const texture of [tempMaskTexture, ...finalMaskTextures]) {
+      resizeTexture(gl, texture, bufferWidth, bufferHeight);
+    }
+    if (backgroundSourceImage) {
+      // Not awaited: the placeholder background shows until the re-crop resolves, as on the initial set.
+      setBackgroundImage(backgroundSourceImage);
+    }
+  }
+
   let backgroundImageDisabled = false;
 
   // Set up uniforms for the composite shader
@@ -116,9 +147,6 @@ export const setupWebGL = (canvas: OffscreenCanvas | HTMLCanvasElement) => {
   gl.uniform1i(frameTextureLocation, 1);
   gl.uniform1i(maskTextureLocation, 2);
 
-  // Store custom background image
-  let customBackgroundImage: ImageBitmap | ImageData | null = null;
-
   function renderFrame(frame: VideoFrame) {
     if (frame.codedWidth === 0 || finalMaskTextures.length === 0) {
       return;
@@ -126,6 +154,8 @@ export const setupWebGL = (canvas: OffscreenCanvas | HTMLCanvasElement) => {
 
     const width = frame.displayWidth;
     const height = frame.displayHeight;
+
+    ensureBuffersMatchCanvas();
 
     // Prepare frame texture
     gl.activeTexture(gl.TEXTURE1);
@@ -197,6 +227,7 @@ export const setupWebGL = (canvas: OffscreenCanvas | HTMLCanvasElement) => {
    */
   async function setBackgroundImage(image: ImageBitmap | null) {
     // Clear existing background
+    backgroundSourceImage = image;
     customBackgroundImage = null;
 
     if (image) {
@@ -230,6 +261,12 @@ export const setupWebGL = (canvas: OffscreenCanvas | HTMLCanvasElement) => {
   }
 
   function updateMask(mask: WebGLTexture) {
+    // Same guard as renderFrame: cleanup() empties the arrays, a late segmentation callback must not touch them.
+    if (finalMaskTextures.length === 0) {
+      return;
+    }
+    ensureBuffersMatchCanvas();
+
     // Use the existing applyBlur function to apply the first blur pass
     // The second blur pass will be written to finalMaskTextures[writeMaskIndex]
 
@@ -297,6 +334,7 @@ export const setupWebGL = (canvas: OffscreenCanvas | HTMLCanvasElement) => {
       }
       customBackgroundImage = null;
     }
+    backgroundSourceImage = null;
     bgBlurTextures = [];
     bgBlurFrameBuffers = [];
     finalMaskTextures = [];

--- a/src/webgl/utils.ts
+++ b/src/webgl/utils.ts
@@ -52,6 +52,20 @@ export function createProgram(
 }
 
 /**
+ * Re-specify a texture's storage at the given size. Works on a framebuffer attachment in place: the
+ * attachment references the texture object, so the framebuffer stays valid.
+ */
+export function resizeTexture(
+  gl: WebGL2RenderingContext,
+  texture: WebGLTexture,
+  width: number,
+  height: number,
+) {
+  gl.bindTexture(gl.TEXTURE_2D, texture);
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+}
+
+/**
  * Create a WebGL framebuffer with the given texture as color attachment
  */
 export function createFramebuffer(
@@ -67,8 +81,7 @@ export function createFramebuffer(
   gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
 
   // Ensure texture dimensions match the provided width and height
-  gl.bindTexture(gl.TEXTURE_2D, texture);
-  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+  resizeTexture(gl, texture, width, height);
 
   // Check if framebuffer is complete
   const status = gl.checkFramebufferStatus(gl.FRAMEBUFFER);


### PR DESCRIPTION
## Summary

The mask and blur buffers are sized once at setup from `getSettings()`, but every frame is rendered at the frame's own size. When the two differ, the mask is written at one size into textures of another and comes out clipped and offset, and on the canvas fallback path the output is stretched into the old shape.

They differ on device rotation mid-call (both paths) and on iPhones from the first frame: `getSettings()` reports the rotated portrait size while `new VideoFrame(video)` reports the landscape sensor buffer.

- `webgl/index.ts`: reallocate the size-dependent textures in place when the canvas size changes (checked in `updateMask` and `renderFrame`) and re-crop a custom background image.
- `ProcessorWrapper.ts`: size the fallback `displayCanvas` to the source video's `videoWidth`/`videoHeight` on each frame.
- `ProcessorWrapper.ts`: a rejected `play()` (`NotAllowedError` on WebKit outside a user gesture) went unhandled and ended the fallback render loop for good, freezing the published track. Keep the loop alive and retry once a second. This happens whenever the processor starts outside a tap, e.g. livekit's reconnect restart, Low Power Mode, or Brave iOS.

Related: #112 fixes the mask half by recreating the textures; this PR resizes them in place and also covers the blur textures, the background image and the fallback output canvas, so it supersedes #112. #127 changes the same paused branch the same way while moving the loop onto a worker timer; whichever lands second rebases one hunk, and the `play()` change can move to its own PR if that is easier.

## Before / after

iPhone, Safari, held upright, no rotation. `getSettings()` says 480x640, frames are 640x480.

| `main` | this branch |
|---|---|
| ![iPhone before](https://github.com/welson-ribbon/track-processors-js/blob/assets/frame-size-demo/frame-size-demo/iphone-before-main.jpg?raw=true) | ![iPhone after](https://github.com/welson-ribbon/track-processors-js/blob/assets/frame-size-demo/frame-size-demo/iphone-after-fix.jpg?raw=true) |

Same phone rotated to landscape mid-call. On `main` the published track keeps the portrait size, so the frame is squeezed into it and shows letterboxed, with the mask off the face.

| `main` | this branch |
|---|---|
| ![iPhone landscape before](https://github.com/welson-ribbon/track-processors-js/blob/assets/frame-size-demo/frame-size-demo/iphone-landscape-before-main.jpg?raw=true) | ![iPhone landscape after](https://github.com/welson-ribbon/track-processors-js/blob/assets/frame-size-demo/frame-size-demo/iphone-landscape-after-fix.jpg?raw=true) |

Rotation mid-call in Chromium, synthetic camera, fallback path forced. Top is `main`, bottom is this branch.

![fallback path rotation](https://github.com/welson-ribbon/track-processors-js/blob/assets/frame-size-demo/frame-size-demo/B-canvas-path-rotation-2-rotate.png?raw=true)

Same captures for the [default path](https://github.com/welson-ribbon/track-processors-js/blob/assets/frame-size-demo/frame-size-demo/C-default-path-rotation-2-rotate.png?raw=true) and the [upright iPhone condition](https://github.com/welson-ribbon/track-processors-js/blob/assets/frame-size-demo/frame-size-demo/A-canvas-path-transposed-settings-1-settle.png?raw=true).

<details>
<summary>Reproducing locally</summary>

The example app cannot hit these paths with a fixed-size desktop camera, so the captures come from a standalone page that feeds a synthetic canvas camera through `BackgroundProcessor` (no server, no camera). It is not part of this PR:

```sh
curl -o example/frame-size-demo.html https://raw.githubusercontent.com/welson-ribbon/track-processors-js/assets/frame-size-demo/frame-size-demo/frame-size-demo.html
curl -o example/frame-size-demo.ts https://raw.githubusercontent.com/welson-ribbon/track-processors-js/assets/frame-size-demo/frame-size-demo/frame-size-demo.ts
pnpm dev   # then open http://localhost:8080/frame-size-demo.html?<query> on main and on this branch
```

The status box under the videos shows the sizes the processor sees and a sharpness probe: the striped shirt reads about 6 when sharp and 0 when blurred, the checkerboard corners about 2 when blurred and 13 to 17 when not.

| Scenario | Query | `main` | this branch |
|---|---|---|---|
| Upright iPhone condition, fallback path | `?path=canvas&settings=transposed` | output 480x640 while frames are 640x480, corners 13 to 17 | output 640x480, corners 2 |
| Rotation, fallback path | `?path=canvas`, click Rotate source | output stays 640x480, shirt 0 | output follows, shirt 6 |
| Rotation, default path | no query, click Rotate source | shirt 0 | shirt 6 |
| Refused `play()` | `?path=canvas&play=gated`, click the page after a few seconds | framesProcessed stays 0 | frames start after the click |

On a phone: put the dev server behind an https tunnel and open `?camera=real`. Safari has no `MediaStreamTrackProcessor`, so it is on the fallback path either way; the `path` line in the status box is the authoritative one.
</details>

<details>
<summary>Notes for review</summary>

- The fallback `displayCanvas` follows `videoWidth`/`videoHeight` rather than the processed frame because on the phone they differ: presented 480x640, frame 640x480 (status box in the screenshots). WebKit keeps the sensor buffer landscape and applies the rotation when the frame is drawn, so the published canvas has to be the presented size. The synthetic run cannot show this; there presented equals frame.
- For a fixed-size camera nothing changes: both new checks are integer compares that return early. A camera or resolution switch goes through `restart()`, which is a fresh setup.
- The paused branch re-arms through `requestAnimationFrame` every frame, like the no-new-frame path, instead of from the `play()` promise, so `cleanup()`'s `cancelAnimationFrame` stays the one place that stops the loop. The 1 s only bounds how often `play()` is called and logged; the loop never waits on it.
- In virtual-background mode the first frame or two after a size change show the placeholder background while the image is re-cropped, the same as when the image is first set.
</details>

## Test plan

- [x] `pnpm lint`, `pnpm build`
- [x] Chromium, both paths, `main` vs this branch: upright iPhone condition, two rotations
- [x] Chromium, `play()` patched to reject until a click: `main` stays at 0 processed frames after the click, this branch starts producing frames on the next retry
- [x] iPhone, Safari, iOS 18: mask correct upright (screenshots above)
- [x] iPhone, Safari: rotate to landscape mid-call, mask and output follow (screenshots above)
